### PR TITLE
fix(load_dotenv): remove load_dotenv()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-llamaindex"
-version = "0.0.35"
+version = "0.0.36"
 description = "UiPath LlamaIndex SDK"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"
@@ -9,7 +9,7 @@ dependencies = [
     "llama-index-embeddings-azure-openai>=0.3.8",
     "llama-index-llms-azure-openai>=0.3.2",
     "openinference-instrumentation-llama-index>=4.3.0",
-    "uipath>=2.1.36, <2.2.0",
+    "uipath>=2.1.54, <2.2.0",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/samples/action-center-hitl-agent/main.py
+++ b/samples/action-center-hitl-agent/main.py
@@ -1,6 +1,5 @@
 import json
 
-from dotenv import load_dotenv
 from llama_index.core.agent.workflow import AgentWorkflow
 from llama_index.core.workflow import (
     Context,
@@ -9,8 +8,6 @@ from llama_index.core.workflow import (
 from llama_index.llms.openai import OpenAI
 
 from uipath_llamaindex.models import CreateActionEvent
-
-load_dotenv()
 
 llm = OpenAI(model="gpt-4o-mini")
 

--- a/samples/multi-agent/main.py
+++ b/samples/multi-agent/main.py
@@ -1,6 +1,5 @@
 import json
 
-from dotenv import load_dotenv
 from llama_index.core.agent.workflow import AgentWorkflow
 from llama_index.core.workflow import (
     Context,
@@ -9,8 +8,6 @@ from llama_index.core.workflow import (
 from llama_index.llms.openai import OpenAI
 
 from uipath_llamaindex.models import InvokeProcessEvent
-
-load_dotenv()
 
 llm = OpenAI(model="gpt-4o-mini")
 

--- a/samples/quickstart-llamacloud/main.py
+++ b/samples/quickstart-llamacloud/main.py
@@ -1,12 +1,9 @@
 import os
 
-from dotenv import load_dotenv
 from llama_cloud_services import LlamaCloudIndex
 from llama_index.core.agent.workflow import FunctionAgent
 from llama_index.llms.openai import OpenAI
 from pydantic import BaseModel, Field
-
-load_dotenv()
 
 # Initialize LlamaCloud Index connections
 company_policy_index = LlamaCloudIndex(

--- a/src/uipath_llamaindex/_cli/_utils/_config.py
+++ b/src/uipath_llamaindex/_cli/_utils/_config.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from dotenv import load_dotenv
 from llama_index.core.workflow import Workflow
 
 logger = logging.getLogger(__name__)
@@ -134,18 +133,6 @@ class LlamaIndexConfig:
                 raise ValueError(
                     f"Missing required fields in llama_index.json: {missing_fields}"
                 )
-
-            if env_file := config.get("env"):
-                env_path = os.path.abspath(os.path.normpath(env_file))
-                if os.path.exists(env_path):
-                    if not load_dotenv(env_path):
-                        # log warning only if dotenv is not empty
-                        if os.path.getsize(env_path) > 0:
-                            logger.warning(
-                                f"Could not load environment variables from {env_path}"
-                            )
-                    else:
-                        logger.debug(f"Loaded environment variables from {env_path}")
 
             self._config = config
             self._load_workflows()

--- a/src/uipath_llamaindex/_cli/cli_run.py
+++ b/src/uipath_llamaindex/_cli/cli_run.py
@@ -3,7 +3,6 @@ import logging
 from os import environ as env
 from typing import Optional
 
-from dotenv import load_dotenv
 from openinference.instrumentation.llama_index import (
     LlamaIndexInstrumentor,
     get_current_span,
@@ -18,7 +17,6 @@ from ._tracing._oteladapter import LlamaIndexExporter
 from ._utils._config import LlamaIndexConfig
 
 logger = logging.getLogger(__name__)
-load_dotenv()
 
 
 def llamaindex_run_middleware(


### PR DESCRIPTION
This pull request removes the use of the `python-dotenv` library and all calls to `load_dotenv()` from both sample scripts and the CLI utility code. 

## Development Package

- Add this package as a dependency in your pyproject.toml:

```toml
[project]
dependencies = [
  # Exact version:
  "uipath-llamaindex==0.0.36.dev1000680211",

  # Any version from PR
  "uipath-llamaindex>=0.0.36.dev1000680000,<0.0.36.dev1000690000"
]

[[tool.uv.index]]
name = "testpypi"
url = "https://test.pypi.org/simple/"
publish-url = "https://test.pypi.org/legacy/"
explicit = true

[tool.uv.sources]
uipath-llamaindex = { index = "testpypi" }
```