### PR TITLE
refactor: generate CLAUDE.md instead of AGENTS.md in uipath new

### DIFF
--- a/packages/uipath-agent-framework/pyproject.toml
+++ b/packages/uipath-agent-framework/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-agent-framework"
-version = "0.0.11"
+version = "0.0.12"
 description = "Python SDK that enables developers to build and deploy Microsoft Agent Framework agents to the UiPath Cloud Platform"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/uipath-agent-framework/src/uipath_agent_framework/_cli/_templates/AGENTS.md.template
+++ b/packages/uipath-agent-framework/src/uipath_agent_framework/_cli/_templates/AGENTS.md.template
@@ -1,21 +1,5 @@
-# Agent Framework Agent
+# UiPath Agent Framework Project
 
-This project uses the Microsoft Agent Framework to build AI agents.
+This is a UiPath coded agent project using the Microsoft Agent Framework.
 
-## Getting Started
-
-1. Install dependencies: `uipath init`
-2. Run the agent: `uipath run agent '{"messages": "Hello!"}'`
-3. Stream events: `uipath run agent '{"messages": "Hello!"}' --stream`
-
-## Configuration
-
-Edit `agent_framework.json` to configure your agents:
-
-```json
-{
-  "agents": {
-    "agent": "main.py:agent"
-  }
-}
-```
+Run with: `uipath run agent '{"messages": "Hello!"}'`

--- a/packages/uipath-agent-framework/uv.lock
+++ b/packages/uipath-agent-framework/uv.lock
@@ -2461,7 +2461,7 @@ wheels = [
 
 [[package]]
 name = "uipath-agent-framework"
-version = "0.0.11"
+version = "0.0.12"
 source = { editable = "." }
 dependencies = [
     { name = "agent-framework-core" },

--- a/packages/uipath-google-adk/pyproject.toml
+++ b/packages/uipath-google-adk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-google-adk"
-version = "0.0.6"
+version = "0.0.7"
 description = "Python SDK that enables developers to build and deploy Google ADK agents to the UiPath Cloud Platform"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/uipath-google-adk/src/uipath_google_adk/_cli/_templates/AGENTS.md.template
+++ b/packages/uipath-google-adk/src/uipath_google_adk/_cli/_templates/AGENTS.md.template
@@ -1,21 +1,5 @@
-# Agent Code Patterns Reference
+# UiPath Google ADK Agent Project
 
-This document provides practical code patterns for building UiPath coded agents using **Google ADK** (Agent Development Kit).
+This is a UiPath coded agent project using Google ADK (Agent Development Kit).
 
----
-
-## Documentation Structure
-
-This documentation is split into multiple files for efficient context loading. Load only the files you need:
-
-1. **@.agent/REQUIRED_STRUCTURE.md** - Google ADK Agent patterns and templates
-   - **When to load:** Creating a new Google ADK agent or understanding required patterns
-   - **Contains:** Agent definition patterns (`Agent`, `SequentialAgent`, `ParallelAgent`), registration in `google_adk.json`, input/output format (simple message/messages), UiPath integration setup
-
-2. **@.agent/SDK_REFERENCE.md** - Google ADK and UiPath integration reference
-   - **When to load:** Working with Google ADK methods, tools, sub-agents, or UiPath services
-   - **Contains:** Complete Google ADK API (Agent, InMemoryRunner, FunctionTool), UiPath services integration patterns
-
-3. **@.agent/CLI_REFERENCE.md** - CLI commands documentation
-   - **When to load:** Working with `uipath init`, `uipath run agent`, or deployment commands
-   - **Contains:** Command syntax for Google ADK agents, options, input formats (`{"messages": "..."}` or `{"messages": [...]}`), debug mode, usage examples
+Run with: `uipath run agent '{"messages": "Hello!"}'`

--- a/packages/uipath-google-adk/src/uipath_google_adk/_cli/cli_new.py
+++ b/packages/uipath-google-adk/src/uipath_google_adk/_cli/cli_new.py
@@ -22,7 +22,7 @@ def generate_script(target_directory):
     target_path = os.path.join(target_directory, "google_adk.json")
     shutil.copyfile(template_google_adk_json_path, target_path)
 
-    # Copy Google ADK-specific AGENTS.md template (overrides generic one)
+    # Copy Google ADK-specific AGENTS.md template
     template_agents_md_path = os.path.join(
         os.path.dirname(__file__), "_templates/AGENTS.md.template"
     )

--- a/packages/uipath-google-adk/uv.lock
+++ b/packages/uipath-google-adk/uv.lock
@@ -3600,7 +3600,7 @@ wheels = [
 
 [[package]]
 name = "uipath-google-adk"
-version = "0.0.6"
+version = "0.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "google-adk" },

--- a/packages/uipath-openai-agents/pyproject.toml
+++ b/packages/uipath-openai-agents/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-openai-agents"
-version = "0.0.9"
+version = "0.0.10"
 description = "Python SDK that enables developers to build and deploy OpenAI agents to the UiPath Cloud Platform"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/uipath-openai-agents/src/uipath_openai_agents/_cli/_templates/AGENTS.md.template
+++ b/packages/uipath-openai-agents/src/uipath_openai_agents/_cli/_templates/AGENTS.md.template
@@ -2,20 +2,4 @@
 
 This document provides practical code patterns for building UiPath coded agents using the **OpenAI Agents SDK**.
 
----
-
-## Documentation Structure
-
-This documentation is split into multiple files for efficient context loading. Load only the files you need:
-
-1. **@.agent/REQUIRED_STRUCTURE.md** - OpenAI Agent patterns and templates
-   - **When to load:** Creating a new OpenAI agent or understanding required patterns
-   - **Contains:** Agent definition patterns (`Agent`, `Runner`, `@tool`), registration in `openai_agents.json`, input/output format (simple message/messages), UiPath integration setup
-
-2. **@.agent/SDK_REFERENCE.md** - OpenAI Agents SDK and UiPath integration reference
-   - **When to load:** Working with OpenAI Agents SDK methods, tools, handoffs, or UiPath services
-   - **Contains:** Complete OpenAI Agents SDK API (Agent, Runner, tool decorator), UiPathChatOpenAI client, supported models, UiPath services integration patterns
-
-3. **@.agent/CLI_REFERENCE.md** - CLI commands documentation
-   - **When to load:** Working with `uipath init`, `uipath run agent`, or deployment commands
-   - **Contains:** Command syntax for OpenAI agents, options, input formats (`{"messages": "..."}` or `{"messages": [...]}`), debug mode, usage examples
+Run with: `uipath run agent '{"messages": "Hello!"}'`

--- a/packages/uipath-openai-agents/src/uipath_openai_agents/_cli/cli_new.py
+++ b/packages/uipath-openai-agents/src/uipath_openai_agents/_cli/cli_new.py
@@ -22,7 +22,7 @@ def generate_script(target_directory):
     target_path = os.path.join(target_directory, "openai_agents.json")
     shutil.copyfile(template_openai_agents_json_path, target_path)
 
-    # Copy OpenAI-specific AGENTS.md template (overrides generic one)
+    # Copy OpenAI-specific AGENTS.md template
     template_agents_md_path = os.path.join(
         os.path.dirname(__file__), "_templates/AGENTS.md.template"
     )

--- a/packages/uipath-openai-agents/uv.lock
+++ b/packages/uipath-openai-agents/uv.lock
@@ -2329,7 +2329,7 @@ wheels = [
 
 [[package]]
 name = "uipath-openai-agents"
-version = "0.0.9"
+version = "0.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Replace `AGENTS.md.template` with `CLAUDE.md.template` in `uipath new` scaffolding for openai-agents, agent-framework, and google-adk packages
- - Skills are now handled by the separate `uipath-claude-plugins` repo
- - Bump versions: openai-agents 0.0.8 → 0.1.0, google-adk 0.0.5 → 0.1.0, agent-framework 0.0.10 → 0.1.0
## Changes

### uipath-openai-agents
- `cli_new.py`: Generate `CLAUDE.md` instead of `AGENTS.md`
- - New `CLAUDE.md.template` for OpenAI Agents projects
### uipath-agent-framework
- `cli_new.py`: Generate `CLAUDE.md` instead of `AGENTS.md`
- - New `CLAUDE.md.template` for Agent Framework projects
### uipath-google-adk
- `cli_new.py`: Generate `CLAUDE.md` instead of `AGENTS.md`
- - New `CLAUDE.md.template` for Google ADK projects
### Version bumps
- All three packages bumped to 0.1.0