### PR TITLE
fix: enable breakpoint injection for uipath dev mode

### DIFF
--- a/packages/uipath-llamaindex/pyproject.toml
+++ b/packages/uipath-llamaindex/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-llamaindex"
-version = "0.5.9"
+version = "0.5.10"
 description = "Python SDK that enables developers to build and deploy LlamaIndex agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-llamaindex/src/uipath_llamaindex/runtime/factory.py
+++ b/packages/uipath-llamaindex/src/uipath_llamaindex/runtime/factory.py
@@ -253,7 +253,7 @@ class UiPathLlamaIndexRuntimeFactory:
             runtime_id=runtime_id,
             entrypoint=entrypoint,
             storage=storage,
-            debug_mode=self.context.command == "debug",
+            debug_mode=self.context.command in ("debug", "dev"),
         )
 
         trigger_manager = UiPathResumeTriggerHandler()

--- a/packages/uipath-llamaindex/uv.lock
+++ b/packages/uipath-llamaindex/uv.lock
@@ -3496,7 +3496,7 @@ wheels = [
 
 [[package]]
 name = "uipath-llamaindex"
-version = "0.5.8"
+version = "0.5.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- `debug_mode` in the llamaindex runtime factory was gated on `command == "debug"` only
- `uipath dev` sets `command="dev"`, so `inject_breakpoints()` was never called
- breakpoints set in the dev console UI silently did nothing for llamaindex workflows
- fix: `debug_mode=self.context.command in ("debug", "dev")`
- bumped `uipath-llamaindex` to `0.5.10`

## Why

langgraph has `interrupt_before` built into the framework, so breakpoints work regardless of the command. llamaindex workflows require explicit injection via `inject_breakpoints()`, which was only wired up for `uipath debug` but not `uipath dev`.