### PR TITLE
fix: default error_on_no_tool_call to false in llm wrappers

### DIFF
--- a/packages/uipath-llamaindex/pyproject.toml
+++ b/packages/uipath-llamaindex/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-llamaindex"
-version = "0.5.9"
+version = "0.5.10"
 description = "Python SDK that enables developers to build and deploy LlamaIndex agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-llamaindex/src/uipath_llamaindex/llms/_openai.py
+++ b/packages/uipath-llamaindex/src/uipath_llamaindex/llms/_openai.py
@@ -2,6 +2,8 @@ import os
 from typing import Any
 
 import httpx
+from llama_index.core.base.llms.types import ChatResponse
+from llama_index.core.tools import ToolSelection
 from llama_index.llms.azure_openai import AzureOpenAI  # type: ignore
 from uipath._utils._ssl_context import get_httpx_client_kwargs
 from uipath.utils import EndpointManager
@@ -87,3 +89,13 @@ class UiPathOpenAI(AzureOpenAI):
         }
         final_kwargs = {**defaults, **kwargs}
         super().__init__(**final_kwargs)
+
+    def get_tool_calls_from_response(
+        self,
+        response: ChatResponse,
+        error_on_no_tool_call: bool = False,
+        **kwargs: Any,
+    ) -> list[ToolSelection]:
+        return super().get_tool_calls_from_response(
+            response, error_on_no_tool_call=error_on_no_tool_call, **kwargs
+        )

--- a/packages/uipath-llamaindex/src/uipath_llamaindex/llms/bedrock.py
+++ b/packages/uipath-llamaindex/src/uipath_llamaindex/llms/bedrock.py
@@ -53,6 +53,7 @@ from llama_index.core.llms.callbacks import (  # noqa: E402
     llm_chat_callback,
     llm_completion_callback,
 )
+from llama_index.core.tools import ToolSelection  # noqa: E402
 from llama_index.llms.bedrock import Bedrock  # type: ignore[import-untyped]
 from llama_index.llms.bedrock_converse import (  # type: ignore[import-untyped]
     BedrockConverse,
@@ -182,6 +183,16 @@ class UiPathChatBedrockConverse(BedrockConverse):
             aws_access_key_id="none",
             aws_secret_access_key="none",
             **kwargs,
+        )
+
+    def get_tool_calls_from_response(
+        self,
+        response: ChatResponse,
+        error_on_no_tool_call: bool = False,
+        **kwargs: Any,
+    ) -> list[ToolSelection]:
+        return super().get_tool_calls_from_response(
+            response, error_on_no_tool_call=error_on_no_tool_call, **kwargs
         )
 
 

--- a/packages/uipath-llamaindex/src/uipath_llamaindex/llms/vertex.py
+++ b/packages/uipath-llamaindex/src/uipath_llamaindex/llms/vertex.py
@@ -52,6 +52,7 @@ from llama_index.core.llms.callbacks import (  # noqa: E402
     llm_chat_callback,
     llm_completion_callback,
 )
+from llama_index.core.tools import ToolSelection  # noqa: E402
 from llama_index.llms.google_genai import GoogleGenAI  # noqa: E402
 
 
@@ -410,3 +411,13 @@ class UiPathVertex(GoogleGenAI):
             )
 
         return gen()
+
+    def get_tool_calls_from_response(
+        self,
+        response: ChatResponse,
+        error_on_no_tool_call: bool = False,
+        **kwargs: Any,
+    ) -> list[ToolSelection]:
+        return super().get_tool_calls_from_response(
+            response, error_on_no_tool_call=error_on_no_tool_call, **kwargs
+        )

--- a/packages/uipath-llamaindex/uv.lock
+++ b/packages/uipath-llamaindex/uv.lock
@@ -3496,7 +3496,7 @@ wheels = [
 
 [[package]]
 name = "uipath-llamaindex"
-version = "0.5.8"
+version = "0.5.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- override get_tool_calls_from_response in bedrock, openai, and vertex wrappers to default error_on_no_tool_call=False
- upstream llama-index defaults to True which raises `ValueError: Expected at least one tool call, but got 0 tool calls.` when the model responds with text instead of tool calls
- bump uipath-llamaindex to 0.5.10

## Why
the upstream default breaks any custom workflow that calls get_tool_calls_from_response without explicitly passing error_on_no_tool_call=False. llama-index's own built-in agents always pass False