### PR TITLE
chore: update pyproject template version to current minor interval

### DIFF
--- a/packages/uipath-llamaindex/pyproject.toml
+++ b/packages/uipath-llamaindex/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-llamaindex"
-version = "0.5.11"
+version = "0.5.12"
 description = "Python SDK that enables developers to build and deploy LlamaIndex agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-llamaindex/src/uipath_llamaindex/_cli/cli_new.py
+++ b/packages/uipath-llamaindex/src/uipath_llamaindex/_cli/cli_new.py
@@ -31,7 +31,7 @@ version = "0.0.1"
 description = "{project_name}"
 authors = [{{ name = "John Doe", email = "john.doe@myemail.com" }}]
 dependencies = [
-    "uipath-llamaindex>=0.1.0",
+    "uipath-llamaindex>=0.5.0, <0.6.0",
     "llama-index-llms-openai>=0.6.10"
 ]
 requires-python = ">=3.11"

--- a/packages/uipath-llamaindex/uv.lock
+++ b/packages/uipath-llamaindex/uv.lock
@@ -3496,7 +3496,7 @@ wheels = [
 
 [[package]]
 name = "uipath-llamaindex"
-version = "0.5.11"
+version = "0.5.12"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Bump uipath-llamaindex package version to 0.5.3 and update the cli new template to generate projects pinned to the current minor interval (>=0.5.0, <0.6.0).