### PR TITLE
chore: bump uipath-runtime to >=0.10.0 across integrations

### DIFF
--- a/packages/uipath-agent-framework/pyproject.toml
+++ b/packages/uipath-agent-framework/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-agent-framework"
-version = "0.0.11"
+version = "0.0.12"
 description = "Python SDK that enables developers to build and deploy Microsoft Agent Framework agents to the UiPath Cloud Platform"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -10,7 +10,7 @@ dependencies = [
     "aiosqlite>=0.20.0",
     "openinference-instrumentation-agent-framework>=0.1.0",
     "uipath>=2.10.0, <2.11.0",
-    "uipath-runtime>=0.9.0, <0.10.0",
+    "uipath-runtime>=0.10.0, <0.11.0",
 ]
 classifiers = [
     "Intended Audience :: Developers",

--- a/packages/uipath-agent-framework/tests/test_hitl_e2e.py
+++ b/packages/uipath-agent-framework/tests/test_hitl_e2e.py
@@ -87,6 +87,9 @@ class MockChatBridge:
     async def emit_exchange_end_event(self) -> None:
         pass
 
+    async def emit_exchange_error_event(self, error: Exception) -> None:
+        pass
+
     async def wait_for_resume(self) -> dict[str, Any]:
         """Return CAS-format approval/rejection response."""
         return {

--- a/packages/uipath-agent-framework/uv.lock
+++ b/packages/uipath-agent-framework/uv.lock
@@ -2299,6 +2299,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlparse"
+version = "0.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2431,7 +2440,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.3"
+version = "2.10.58"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "applicationinsights" },
@@ -2454,14 +2463,14 @@ dependencies = [
     { name = "uipath-platform" },
     { name = "uipath-runtime" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/88/b0/d8dc7344201fae810f8e5f578163dd24e86f81374fee3f7c54011abf9626/uipath-2.10.3.tar.gz", hash = "sha256:8cb0bf61df0cb8cde161d295535be8679cf535f9dc7e6429c8f48c82108822ce", size = 2454178, upload-time = "2026-03-01T13:00:24.937Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/49/f8b42feee9b488341510bd7b1ae4341895587ff208455c4e4b3bdff35279/uipath-2.10.58.tar.gz", hash = "sha256:ce7a67cfa2c96a563e6174a77c760803b4ce74966473962beea227d9cf7ab530", size = 2933008, upload-time = "2026-04-28T08:11:32.029Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/2a/9580cec05570d1484c56260a441cc93c3c96164f01605785fe3d3c234b55/uipath-2.10.3-py3-none-any.whl", hash = "sha256:4a4f9491eeb6118e812ee3bce7f37d97910d4c38a5a96f05bfc31fa8fb3f963e", size = 352944, upload-time = "2026-03-01T13:00:22.746Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/84/313499014a73560d9bf716a46bdcd272126eae48b320789db4a33e04ea13/uipath-2.10.58-py3-none-any.whl", hash = "sha256:30d52cef46962c6fb584a11d375bb108f3d674e1023b0ae48237e0cd2e137108", size = 389192, upload-time = "2026-04-28T08:11:29.854Z" },
 ]
 
 [[package]]
 name = "uipath-agent-framework"
-version = "0.0.11"
+version = "0.0.12"
 source = { editable = "." }
 dependencies = [
     { name = "agent-framework-core" },
@@ -2498,7 +2507,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.43.0" },
     { name = "openinference-instrumentation-agent-framework", specifier = ">=0.1.0" },
     { name = "uipath", specifier = ">=2.10.0,<2.11.0" },
-    { name = "uipath-runtime", specifier = ">=0.9.0,<0.10.0" },
+    { name = "uipath-runtime", specifier = ">=0.10.0,<0.11.0" },
 ]
 provides-extras = ["anthropic"]
 
@@ -2515,44 +2524,45 @@ dev = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.4"
+version = "0.5.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/00/fd070d738798c3bfb39398de1bb9375e99ab455fb0978354a5714bbd90e8/uipath_core-0.5.4.tar.gz", hash = "sha256:3cbc12b3632f7ec80ea1bbc6f758a578f81b6045ba625382f922b4b4782dbdce", size = 119114, upload-time = "2026-03-02T14:57:39.924Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/32/47220dd78799dc5c862d8bb30ce15d8979d91c066d210643fdbf83f3b203/uipath_core-0.5.14.tar.gz", hash = "sha256:da50f724f969373548cc1acf1cef83b5c79c925cf513d47a2b9c984590908556", size = 117665, upload-time = "2026-04-29T08:03:07.743Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/83/59043dba044d5c2f418080d60cb8f902be856bb6e8985b2758311d03b597/uipath_core-0.5.4-py3-none-any.whl", hash = "sha256:92f80170c39cd8b4cc0341277140ab25862d251cc2271c4013bba24ac387b314", size = 42873, upload-time = "2026-03-02T14:57:38.485Z" },
+    { url = "https://files.pythonhosted.org/packages/48/da/29ca8cd4e64c940339649f2eb8ec604911df08fdc41395f6b4473ca5267f/uipath_core-0.5.14-py3-none-any.whl", hash = "sha256:09bab428b50da0f2757291dcbc992e932976578f16f20070e2eadeea13636b6a", size = 44299, upload-time = "2026-04-29T08:03:06.418Z" },
 ]
 
 [[package]]
 name = "uipath-platform"
-version = "0.0.8"
+version = "0.1.39"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic-function-models" },
+    { name = "sqlparse" },
     { name = "tenacity" },
     { name = "truststore" },
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/ef/d412406301deab442f7b188eaf6672e8a01e85d85e80376082da62bb69d4/uipath_platform-0.0.8.tar.gz", hash = "sha256:b824671e2eafac20569edd51c7264311386743aee097cd2c53596a2c662d3159", size = 262059, upload-time = "2026-03-02T10:43:52.986Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/ac/0c685182ecbc35f54a00469c4249282008315d1e71f9dbdee02090aba4c9/uipath_platform-0.1.39.tar.gz", hash = "sha256:9b025221dd109bf3613c846fc7c6ce4c076f061908432026b9c6f8700299522b", size = 329711, upload-time = "2026-04-28T10:46:47.246Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/96/e10bdc337253f2a7b5033aabf2958c3317fb94561711e62167db08ccef17/uipath_platform-0.0.8-py3-none-any.whl", hash = "sha256:11affe53b2fc6399fdfb87b195d0d480f8fcae78027ea3ed8405f498ac33e608", size = 156272, upload-time = "2026-03-02T10:43:51.718Z" },
+    { url = "https://files.pythonhosted.org/packages/04/dd/113ab28e414db7c2f633821427919bfb6395ddbae330d910d1ec1f03f6a6/uipath_platform-0.1.39-py3-none-any.whl", hash = "sha256:faf223d3059cb28e13a83b1aff6cdec50988bbc5c422d76e7bd9b119887ed145", size = 217542, upload-time = "2026-04-28T10:46:45.215Z" },
 ]
 
 [[package]]
 name = "uipath-runtime"
-version = "0.9.2"
+version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/33/472056853c70fe350446f11a223e5af1b7122c804a05d1589a21ffdec9ee/uipath_runtime-0.9.2.tar.gz", hash = "sha256:db4fc26fe1c4c4d3b3d7d55d4c664c3ca0f111652583640ba745e3840517d5b1", size = 139286, upload-time = "2026-02-27T08:31:34.645Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/a5/3643d567b291a584de3b9ff1b39734db8041e5c09a97256426212bbe1f33/uipath_runtime-0.10.2.tar.gz", hash = "sha256:885183183f658aa0af785d2cc268426a583b1a6f12276f5bbafa797323217167", size = 141197, upload-time = "2026-04-29T08:10:33.261Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/8c/ccc1bf2610243bdb3ba39547666be33b66a3959e53022a1209a4c893e4cc/uipath_runtime-0.9.2-py3-none-any.whl", hash = "sha256:6a08e86d68ccbc2cb34dc2d101b9cec54b100d33587d730dfc0e22ae80a7c4c8", size = 41704, upload-time = "2026-02-27T08:31:33.118Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/52/b50ad909e7025f8731422f0cf62c1143d674c445fe128e94d7f652bdfaa3/uipath_runtime-0.10.2-py3-none-any.whl", hash = "sha256:394c78d1666fc049ceab30d65faaf8f9f51c97831ef67468a174bf2ffd7d2217", size = 43058, upload-time = "2026-04-29T08:10:31.315Z" },
 ]
 
 [[package]]

--- a/packages/uipath-google-adk/pyproject.toml
+++ b/packages/uipath-google-adk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-google-adk"
-version = "0.0.6"
+version = "0.0.7"
 description = "Python SDK that enables developers to build and deploy Google ADK agents to the UiPath Cloud Platform"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -8,7 +8,7 @@ dependencies = [
     "google-adk>=1.25.1",
     "openinference-instrumentation-google-adk>=0.1.9",
     "uipath>=2.10.0, <2.11.0",
-    "uipath-runtime>=0.9.0, <0.10.0",
+    "uipath-runtime>=0.10.0, <0.11.0",
 ]
 classifiers = [
     "Intended Audience :: Developers",

--- a/packages/uipath-google-adk/uv.lock
+++ b/packages/uipath-google-adk/uv.lock
@@ -1320,7 +1320,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/e8/2e1462c8fdbe0f210feb5ac7ad2d9029af8be3bf45bd9fa39765f821642f/greenlet-3.3.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5fd23b9bc6d37b563211c6abbb1b3cab27db385a4449af5c32e932f93017080c", size = 274974, upload-time = "2026-01-23T15:31:02.891Z" },
     { url = "https://files.pythonhosted.org/packages/7e/a8/530a401419a6b302af59f67aaf0b9ba1015855ea7e56c036b5928793c5bd/greenlet-3.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:09f51496a0bfbaa9d74d36a52d2580d1ef5ed4fdfcff0a73730abfbbbe1403dd", size = 577175, upload-time = "2026-01-23T16:00:56.213Z" },
     { url = "https://files.pythonhosted.org/packages/8e/89/7e812bb9c05e1aaef9b597ac1d0962b9021d2c6269354966451e885c4e6b/greenlet-3.3.1-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb0feb07fe6e6a74615ee62a880007d976cf739b6669cce95daa7373d4fc69c5", size = 590401, upload-time = "2026-01-23T16:05:26.365Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ae/e2d5f0e59b94a2269b68a629173263fa40b63da32f5c231307c349315871/greenlet-3.3.1-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:67ea3fc73c8cd92f42467a72b75e8f05ed51a0e9b1d15398c913416f2dafd49f", size = 601161, upload-time = "2026-01-23T16:15:53.456Z" },
     { url = "https://files.pythonhosted.org/packages/5c/ae/8d472e1f5ac5efe55c563f3eabb38c98a44b832602e12910750a7c025802/greenlet-3.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39eda9ba259cc9801da05351eaa8576e9aa83eb9411e8f0c299e05d712a210f2", size = 590272, upload-time = "2026-01-23T15:32:49.411Z" },
     { url = "https://files.pythonhosted.org/packages/a8/51/0fde34bebfcadc833550717eade64e35ec8738e6b097d5d248274a01258b/greenlet-3.3.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2e7e882f83149f0a71ac822ebf156d902e7a5d22c9045e3e0d1daf59cee2cc9", size = 1550729, upload-time = "2026-01-23T16:04:20.867Z" },
     { url = "https://files.pythonhosted.org/packages/16/c9/2fb47bee83b25b119d5a35d580807bb8b92480a54b68fef009a02945629f/greenlet-3.3.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:80aa4d79eb5564f2e0a6144fcc744b5a37c56c4a92d60920720e99210d88db0f", size = 1615552, upload-time = "2026-01-23T15:33:45.743Z" },
@@ -1329,7 +1328,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/c8/9d76a66421d1ae24340dfae7e79c313957f6e3195c144d2c73333b5bfe34/greenlet-3.3.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:7e806ca53acf6d15a888405880766ec84721aa4181261cd11a457dfe9a7a4975", size = 276443, upload-time = "2026-01-23T15:30:10.066Z" },
     { url = "https://files.pythonhosted.org/packages/81/99/401ff34bb3c032d1f10477d199724f5e5f6fbfb59816ad1455c79c1eb8e7/greenlet-3.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d842c94b9155f1c9b3058036c24ffb8ff78b428414a19792b2380be9cecf4f36", size = 597359, upload-time = "2026-01-23T16:00:57.394Z" },
     { url = "https://files.pythonhosted.org/packages/2b/bc/4dcc0871ed557792d304f50be0f7487a14e017952ec689effe2180a6ff35/greenlet-3.3.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:20fedaadd422fa02695f82093f9a98bad3dab5fcda793c658b945fcde2ab27ba", size = 607805, upload-time = "2026-01-23T16:05:28.068Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/cd/7a7ca57588dac3389e97f7c9521cb6641fd8b6602faf1eaa4188384757df/greenlet-3.3.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c620051669fd04ac6b60ebc70478210119c56e2d5d5df848baec4312e260e4ca", size = 622363, upload-time = "2026-01-23T16:15:54.754Z" },
     { url = "https://files.pythonhosted.org/packages/cf/05/821587cf19e2ce1f2b24945d890b164401e5085f9d09cbd969b0c193cd20/greenlet-3.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14194f5f4305800ff329cbf02c5fcc88f01886cadd29941b807668a45f0d2336", size = 609947, upload-time = "2026-01-23T15:32:51.004Z" },
     { url = "https://files.pythonhosted.org/packages/a4/52/ee8c46ed9f8babaa93a19e577f26e3d28a519feac6350ed6f25f1afee7e9/greenlet-3.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7b2fe4150a0cf59f847a67db8c155ac36aed89080a6a639e9f16df5d6c6096f1", size = 1567487, upload-time = "2026-01-23T16:04:22.125Z" },
     { url = "https://files.pythonhosted.org/packages/8f/7c/456a74f07029597626f3a6db71b273a3632aecb9afafeeca452cfa633197/greenlet-3.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:49f4ad195d45f4a66a0eb9c1ba4832bb380570d361912fa3554746830d332149", size = 1636087, upload-time = "2026-01-23T15:33:47.486Z" },
@@ -1338,7 +1336,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/ab/d26750f2b7242c2b90ea2ad71de70cfcd73a948a49513188a0fc0d6fc15a/greenlet-3.3.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:7ab327905cabb0622adca5971e488064e35115430cec2c35a50fd36e72a315b3", size = 275205, upload-time = "2026-01-23T15:30:24.556Z" },
     { url = "https://files.pythonhosted.org/packages/10/d3/be7d19e8fad7c5a78eeefb2d896a08cd4643e1e90c605c4be3b46264998f/greenlet-3.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:65be2f026ca6a176f88fb935ee23c18333ccea97048076aef4db1ef5bc0713ac", size = 599284, upload-time = "2026-01-23T16:00:58.584Z" },
     { url = "https://files.pythonhosted.org/packages/ae/21/fe703aaa056fdb0f17e5afd4b5c80195bbdab701208918938bd15b00d39b/greenlet-3.3.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7a3ae05b3d225b4155bda56b072ceb09d05e974bc74be6c3fc15463cf69f33fd", size = 610274, upload-time = "2026-01-23T16:05:29.312Z" },
-    { url = "https://files.pythonhosted.org/packages/06/00/95df0b6a935103c0452dad2203f5be8377e551b8466a29650c4c5a5af6cc/greenlet-3.3.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:12184c61e5d64268a160226fb4818af4df02cfead8379d7f8b99a56c3a54ff3e", size = 624375, upload-time = "2026-01-23T16:15:55.915Z" },
     { url = "https://files.pythonhosted.org/packages/cb/86/5c6ab23bb3c28c21ed6bebad006515cfe08b04613eb105ca0041fecca852/greenlet-3.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6423481193bbbe871313de5fd06a082f2649e7ce6e08015d2a76c1e9186ca5b3", size = 612904, upload-time = "2026-01-23T15:32:52.317Z" },
     { url = "https://files.pythonhosted.org/packages/c2/f3/7949994264e22639e40718c2daf6f6df5169bf48fb038c008a489ec53a50/greenlet-3.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:33a956fe78bbbda82bfc95e128d61129b32d66bcf0a20a1f0c08aa4839ffa951", size = 1567316, upload-time = "2026-01-23T16:04:23.316Z" },
     { url = "https://files.pythonhosted.org/packages/8d/6e/d73c94d13b6465e9f7cd6231c68abde838bb22408596c05d9059830b7872/greenlet-3.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4b065d3284be43728dd280f6f9a13990b56470b81be20375a207cdc814a983f2", size = 1636549, upload-time = "2026-01-23T15:33:48.643Z" },
@@ -1347,7 +1344,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/fb/011c7c717213182caf78084a9bea51c8590b0afda98001f69d9f853a495b/greenlet-3.3.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:bd59acd8529b372775cd0fcbc5f420ae20681c5b045ce25bd453ed8455ab99b5", size = 275737, upload-time = "2026-01-23T15:32:16.889Z" },
     { url = "https://files.pythonhosted.org/packages/41/2e/a3a417d620363fdbb08a48b1dd582956a46a61bf8fd27ee8164f9dfe87c2/greenlet-3.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b31c05dd84ef6871dd47120386aed35323c944d86c3d91a17c4b8d23df62f15b", size = 646422, upload-time = "2026-01-23T16:01:00.354Z" },
     { url = "https://files.pythonhosted.org/packages/b4/09/c6c4a0db47defafd2d6bab8ddfe47ad19963b4e30f5bed84d75328059f8c/greenlet-3.3.1-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:02925a0bfffc41e542c70aa14c7eda3593e4d7e274bfcccca1827e6c0875902e", size = 658219, upload-time = "2026-01-23T16:05:30.956Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/89/b95f2ddcc5f3c2bc09c8ee8d77be312df7f9e7175703ab780f2014a0e781/greenlet-3.3.1-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3e0f3878ca3a3ff63ab4ea478585942b53df66ddde327b59ecb191b19dbbd62d", size = 671455, upload-time = "2026-01-23T16:15:57.232Z" },
     { url = "https://files.pythonhosted.org/packages/80/38/9d42d60dffb04b45f03dbab9430898352dba277758640751dc5cc316c521/greenlet-3.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34a729e2e4e4ffe9ae2408d5ecaf12f944853f40ad724929b7585bca808a9d6f", size = 660237, upload-time = "2026-01-23T15:32:53.967Z" },
     { url = "https://files.pythonhosted.org/packages/96/61/373c30b7197f9e756e4c81ae90a8d55dc3598c17673f91f4d31c3c689c3f/greenlet-3.3.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:aec9ab04e82918e623415947921dea15851b152b822661cce3f8e4393c3df683", size = 1615261, upload-time = "2026-01-23T16:04:25.066Z" },
     { url = "https://files.pythonhosted.org/packages/fd/d3/ca534310343f5945316f9451e953dcd89b36fe7a19de652a1dc5a0eeef3f/greenlet-3.3.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:71c767cf281a80d02b6c1bdc41c9468e1f5a494fb11bc8688c360524e273d7b1", size = 1683719, upload-time = "2026-01-23T15:33:50.61Z" },
@@ -1356,7 +1352,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/28/24/cbbec49bacdcc9ec652a81d3efef7b59f326697e7edf6ed775a5e08e54c2/greenlet-3.3.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:3e63252943c921b90abb035ebe9de832c436401d9c45f262d80e2d06cc659242", size = 282706, upload-time = "2026-01-23T15:33:05.525Z" },
     { url = "https://files.pythonhosted.org/packages/86/2e/4f2b9323c144c4fe8842a4e0d92121465485c3c2c5b9e9b30a52e80f523f/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76e39058e68eb125de10c92524573924e827927df5d3891fbc97bd55764a8774", size = 651209, upload-time = "2026-01-23T16:01:01.517Z" },
     { url = "https://files.pythonhosted.org/packages/d9/87/50ca60e515f5bb55a2fbc5f0c9b5b156de7d2fc51a0a69abc9d23914a237/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9f9d5e7a9310b7a2f416dd13d2e3fd8b42d803968ea580b7c0f322ccb389b97", size = 654300, upload-time = "2026-01-23T16:05:32.199Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/25/c51a63f3f463171e09cb586eb64db0861eb06667ab01a7968371a24c4f3b/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b9721549a95db96689458a1e0ae32412ca18776ed004463df3a9299c1b257ab", size = 662574, upload-time = "2026-01-23T16:15:58.364Z" },
     { url = "https://files.pythonhosted.org/packages/1d/94/74310866dfa2b73dd08659a3d18762f83985ad3281901ba0ee9a815194fb/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:92497c78adf3ac703b57f1e3813c2d874f27f71a178f9ea5887855da413cd6d2", size = 653842, upload-time = "2026-01-23T15:32:55.671Z" },
     { url = "https://files.pythonhosted.org/packages/97/43/8bf0ffa3d498eeee4c58c212a3905dd6146c01c8dc0b0a046481ca29b18c/greenlet-3.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ed6b402bc74d6557a705e197d47f9063733091ed6357b3de33619d8a8d93ac53", size = 1614917, upload-time = "2026-01-23T16:04:26.276Z" },
     { url = "https://files.pythonhosted.org/packages/89/90/a3be7a5f378fc6e84abe4dcfb2ba32b07786861172e502388b4c90000d1b/greenlet-3.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:59913f1e5ada20fde795ba906916aea25d442abcc0593fba7e26c92b7ad76249", size = 1676092, upload-time = "2026-01-23T15:33:52.176Z" },
@@ -3556,7 +3551,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.3"
+version = "2.10.58"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "applicationinsights" },
@@ -3579,28 +3574,28 @@ dependencies = [
     { name = "uipath-platform" },
     { name = "uipath-runtime" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/88/b0/d8dc7344201fae810f8e5f578163dd24e86f81374fee3f7c54011abf9626/uipath-2.10.3.tar.gz", hash = "sha256:8cb0bf61df0cb8cde161d295535be8679cf535f9dc7e6429c8f48c82108822ce", size = 2454178, upload-time = "2026-03-01T13:00:24.937Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/49/f8b42feee9b488341510bd7b1ae4341895587ff208455c4e4b3bdff35279/uipath-2.10.58.tar.gz", hash = "sha256:ce7a67cfa2c96a563e6174a77c760803b4ce74966473962beea227d9cf7ab530", size = 2933008, upload-time = "2026-04-28T08:11:32.029Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/2a/9580cec05570d1484c56260a441cc93c3c96164f01605785fe3d3c234b55/uipath-2.10.3-py3-none-any.whl", hash = "sha256:4a4f9491eeb6118e812ee3bce7f37d97910d4c38a5a96f05bfc31fa8fb3f963e", size = 352944, upload-time = "2026-03-01T13:00:22.746Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/84/313499014a73560d9bf716a46bdcd272126eae48b320789db4a33e04ea13/uipath-2.10.58-py3-none-any.whl", hash = "sha256:30d52cef46962c6fb584a11d375bb108f3d674e1023b0ae48237e0cd2e137108", size = 389192, upload-time = "2026-04-28T08:11:29.854Z" },
 ]
 
 [[package]]
 name = "uipath-core"
-version = "0.5.4"
+version = "0.5.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/00/fd070d738798c3bfb39398de1bb9375e99ab455fb0978354a5714bbd90e8/uipath_core-0.5.4.tar.gz", hash = "sha256:3cbc12b3632f7ec80ea1bbc6f758a578f81b6045ba625382f922b4b4782dbdce", size = 119114, upload-time = "2026-03-02T14:57:39.924Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/32/47220dd78799dc5c862d8bb30ce15d8979d91c066d210643fdbf83f3b203/uipath_core-0.5.14.tar.gz", hash = "sha256:da50f724f969373548cc1acf1cef83b5c79c925cf513d47a2b9c984590908556", size = 117665, upload-time = "2026-04-29T08:03:07.743Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/83/59043dba044d5c2f418080d60cb8f902be856bb6e8985b2758311d03b597/uipath_core-0.5.4-py3-none-any.whl", hash = "sha256:92f80170c39cd8b4cc0341277140ab25862d251cc2271c4013bba24ac387b314", size = 42873, upload-time = "2026-03-02T14:57:38.485Z" },
+    { url = "https://files.pythonhosted.org/packages/48/da/29ca8cd4e64c940339649f2eb8ec604911df08fdc41395f6b4473ca5267f/uipath_core-0.5.14-py3-none-any.whl", hash = "sha256:09bab428b50da0f2757291dcbc992e932976578f16f20070e2eadeea13636b6a", size = 44299, upload-time = "2026-04-29T08:03:06.418Z" },
 ]
 
 [[package]]
 name = "uipath-google-adk"
-version = "0.0.6"
+version = "0.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "google-adk" },
@@ -3631,7 +3626,7 @@ requires-dist = [
     { name = "google-adk", specifier = ">=1.25.1" },
     { name = "openinference-instrumentation-google-adk", specifier = ">=0.1.9" },
     { name = "uipath", specifier = ">=2.10.0,<2.11.0" },
-    { name = "uipath-runtime", specifier = ">=0.9.0,<0.10.0" },
+    { name = "uipath-runtime", specifier = ">=0.10.0,<0.11.0" },
 ]
 provides-extras = ["anthropic"]
 
@@ -3648,30 +3643,31 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.0.8"
+version = "0.1.39"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic-function-models" },
+    { name = "sqlparse" },
     { name = "tenacity" },
     { name = "truststore" },
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/ef/d412406301deab442f7b188eaf6672e8a01e85d85e80376082da62bb69d4/uipath_platform-0.0.8.tar.gz", hash = "sha256:b824671e2eafac20569edd51c7264311386743aee097cd2c53596a2c662d3159", size = 262059, upload-time = "2026-03-02T10:43:52.986Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/ac/0c685182ecbc35f54a00469c4249282008315d1e71f9dbdee02090aba4c9/uipath_platform-0.1.39.tar.gz", hash = "sha256:9b025221dd109bf3613c846fc7c6ce4c076f061908432026b9c6f8700299522b", size = 329711, upload-time = "2026-04-28T10:46:47.246Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/96/e10bdc337253f2a7b5033aabf2958c3317fb94561711e62167db08ccef17/uipath_platform-0.0.8-py3-none-any.whl", hash = "sha256:11affe53b2fc6399fdfb87b195d0d480f8fcae78027ea3ed8405f498ac33e608", size = 156272, upload-time = "2026-03-02T10:43:51.718Z" },
+    { url = "https://files.pythonhosted.org/packages/04/dd/113ab28e414db7c2f633821427919bfb6395ddbae330d910d1ec1f03f6a6/uipath_platform-0.1.39-py3-none-any.whl", hash = "sha256:faf223d3059cb28e13a83b1aff6cdec50988bbc5c422d76e7bd9b119887ed145", size = 217542, upload-time = "2026-04-28T10:46:45.215Z" },
 ]
 
 [[package]]
 name = "uipath-runtime"
-version = "0.9.2"
+version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/33/472056853c70fe350446f11a223e5af1b7122c804a05d1589a21ffdec9ee/uipath_runtime-0.9.2.tar.gz", hash = "sha256:db4fc26fe1c4c4d3b3d7d55d4c664c3ca0f111652583640ba745e3840517d5b1", size = 139286, upload-time = "2026-02-27T08:31:34.645Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/a5/3643d567b291a584de3b9ff1b39734db8041e5c09a97256426212bbe1f33/uipath_runtime-0.10.2.tar.gz", hash = "sha256:885183183f658aa0af785d2cc268426a583b1a6f12276f5bbafa797323217167", size = 141197, upload-time = "2026-04-29T08:10:33.261Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/8c/ccc1bf2610243bdb3ba39547666be33b66a3959e53022a1209a4c893e4cc/uipath_runtime-0.9.2-py3-none-any.whl", hash = "sha256:6a08e86d68ccbc2cb34dc2d101b9cec54b100d33587d730dfc0e22ae80a7c4c8", size = 41704, upload-time = "2026-02-27T08:31:33.118Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/52/b50ad909e7025f8731422f0cf62c1143d674c445fe128e94d7f652bdfaa3/uipath_runtime-0.10.2-py3-none-any.whl", hash = "sha256:394c78d1666fc049ceab30d65faaf8f9f51c97831ef67468a174bf2ffd7d2217", size = 43058, upload-time = "2026-04-29T08:10:31.315Z" },
 ]
 
 [[package]]

--- a/packages/uipath-openai-agents/pyproject.toml
+++ b/packages/uipath-openai-agents/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-openai-agents"
-version = "0.0.9"
+version = "0.0.10"
 description = "Python SDK that enables developers to build and deploy OpenAI agents to the UiPath Cloud Platform"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -10,7 +10,7 @@ dependencies = [
     "openai-agents>=0.6.5",
     "openinference-instrumentation-openai-agents>=1.4.0",
     "uipath>=2.10.0, <2.11.0",
-    "uipath-runtime>=0.9.0, <0.10.0",
+    "uipath-runtime>=0.10.0, <0.11.0",
 ]
 classifiers = [
     "Intended Audience :: Developers",

--- a/packages/uipath-openai-agents/tests/cli/test_init.py
+++ b/packages/uipath-openai-agents/tests/cli/test_init.py
@@ -30,6 +30,12 @@ class TestInit:
             with open("openai_agents.json", "w") as f:
                 f.write(openai_agents_config)
 
+            with open("pyproject.toml", "w") as f:
+                f.write(
+                    '[project]\nname = "test-project"\nversion = "0.1.0"\n'
+                    'description = "Test project"\n'
+                )
+
             result = runner.invoke(cli, ["init"])
             assert result.exit_code == 0
             assert os.path.exists("entry-points.json")
@@ -86,6 +92,12 @@ class TestInit:
 
             with open("openai_agents.json", "w") as f:
                 f.write(openai_agents_config)
+
+            with open("pyproject.toml", "w") as f:
+                f.write(
+                    '[project]\nname = "test-project"\nversion = "0.1.0"\n'
+                    'description = "Test project"\n'
+                )
 
             result = runner.invoke(cli, ["init"])
             assert result.exit_code == 0

--- a/packages/uipath-openai-agents/uv.lock
+++ b/packages/uipath-openai-agents/uv.lock
@@ -2141,6 +2141,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlparse"
+version = "0.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2285,7 +2294,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.3"
+version = "2.10.58"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "applicationinsights" },
@@ -2308,28 +2317,28 @@ dependencies = [
     { name = "uipath-platform" },
     { name = "uipath-runtime" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/88/b0/d8dc7344201fae810f8e5f578163dd24e86f81374fee3f7c54011abf9626/uipath-2.10.3.tar.gz", hash = "sha256:8cb0bf61df0cb8cde161d295535be8679cf535f9dc7e6429c8f48c82108822ce", size = 2454178, upload-time = "2026-03-01T13:00:24.937Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/49/f8b42feee9b488341510bd7b1ae4341895587ff208455c4e4b3bdff35279/uipath-2.10.58.tar.gz", hash = "sha256:ce7a67cfa2c96a563e6174a77c760803b4ce74966473962beea227d9cf7ab530", size = 2933008, upload-time = "2026-04-28T08:11:32.029Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/2a/9580cec05570d1484c56260a441cc93c3c96164f01605785fe3d3c234b55/uipath-2.10.3-py3-none-any.whl", hash = "sha256:4a4f9491eeb6118e812ee3bce7f37d97910d4c38a5a96f05bfc31fa8fb3f963e", size = 352944, upload-time = "2026-03-01T13:00:22.746Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/84/313499014a73560d9bf716a46bdcd272126eae48b320789db4a33e04ea13/uipath-2.10.58-py3-none-any.whl", hash = "sha256:30d52cef46962c6fb584a11d375bb108f3d674e1023b0ae48237e0cd2e137108", size = 389192, upload-time = "2026-04-28T08:11:29.854Z" },
 ]
 
 [[package]]
 name = "uipath-core"
-version = "0.5.4"
+version = "0.5.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/00/fd070d738798c3bfb39398de1bb9375e99ab455fb0978354a5714bbd90e8/uipath_core-0.5.4.tar.gz", hash = "sha256:3cbc12b3632f7ec80ea1bbc6f758a578f81b6045ba625382f922b4b4782dbdce", size = 119114, upload-time = "2026-03-02T14:57:39.924Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/32/47220dd78799dc5c862d8bb30ce15d8979d91c066d210643fdbf83f3b203/uipath_core-0.5.14.tar.gz", hash = "sha256:da50f724f969373548cc1acf1cef83b5c79c925cf513d47a2b9c984590908556", size = 117665, upload-time = "2026-04-29T08:03:07.743Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/83/59043dba044d5c2f418080d60cb8f902be856bb6e8985b2758311d03b597/uipath_core-0.5.4-py3-none-any.whl", hash = "sha256:92f80170c39cd8b4cc0341277140ab25862d251cc2271c4013bba24ac387b314", size = 42873, upload-time = "2026-03-02T14:57:38.485Z" },
+    { url = "https://files.pythonhosted.org/packages/48/da/29ca8cd4e64c940339649f2eb8ec604911df08fdc41395f6b4473ca5267f/uipath_core-0.5.14-py3-none-any.whl", hash = "sha256:09bab428b50da0f2757291dcbc992e932976578f16f20070e2eadeea13636b6a", size = 44299, upload-time = "2026-04-29T08:03:06.418Z" },
 ]
 
 [[package]]
 name = "uipath-openai-agents"
-version = "0.0.9"
+version = "0.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -2358,7 +2367,7 @@ requires-dist = [
     { name = "openai-agents", specifier = ">=0.6.5" },
     { name = "openinference-instrumentation-openai-agents", specifier = ">=1.4.0" },
     { name = "uipath", specifier = ">=2.10.0,<2.11.0" },
-    { name = "uipath-runtime", specifier = ">=0.9.0,<0.10.0" },
+    { name = "uipath-runtime", specifier = ">=0.10.0,<0.11.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -2374,30 +2383,31 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.0.8"
+version = "0.1.39"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic-function-models" },
+    { name = "sqlparse" },
     { name = "tenacity" },
     { name = "truststore" },
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/ef/d412406301deab442f7b188eaf6672e8a01e85d85e80376082da62bb69d4/uipath_platform-0.0.8.tar.gz", hash = "sha256:b824671e2eafac20569edd51c7264311386743aee097cd2c53596a2c662d3159", size = 262059, upload-time = "2026-03-02T10:43:52.986Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/ac/0c685182ecbc35f54a00469c4249282008315d1e71f9dbdee02090aba4c9/uipath_platform-0.1.39.tar.gz", hash = "sha256:9b025221dd109bf3613c846fc7c6ce4c076f061908432026b9c6f8700299522b", size = 329711, upload-time = "2026-04-28T10:46:47.246Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/96/e10bdc337253f2a7b5033aabf2958c3317fb94561711e62167db08ccef17/uipath_platform-0.0.8-py3-none-any.whl", hash = "sha256:11affe53b2fc6399fdfb87b195d0d480f8fcae78027ea3ed8405f498ac33e608", size = 156272, upload-time = "2026-03-02T10:43:51.718Z" },
+    { url = "https://files.pythonhosted.org/packages/04/dd/113ab28e414db7c2f633821427919bfb6395ddbae330d910d1ec1f03f6a6/uipath_platform-0.1.39-py3-none-any.whl", hash = "sha256:faf223d3059cb28e13a83b1aff6cdec50988bbc5c422d76e7bd9b119887ed145", size = 217542, upload-time = "2026-04-28T10:46:45.215Z" },
 ]
 
 [[package]]
 name = "uipath-runtime"
-version = "0.9.2"
+version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/33/472056853c70fe350446f11a223e5af1b7122c804a05d1589a21ffdec9ee/uipath_runtime-0.9.2.tar.gz", hash = "sha256:db4fc26fe1c4c4d3b3d7d55d4c664c3ca0f111652583640ba745e3840517d5b1", size = 139286, upload-time = "2026-02-27T08:31:34.645Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/a5/3643d567b291a584de3b9ff1b39734db8041e5c09a97256426212bbe1f33/uipath_runtime-0.10.2.tar.gz", hash = "sha256:885183183f658aa0af785d2cc268426a583b1a6f12276f5bbafa797323217167", size = 141197, upload-time = "2026-04-29T08:10:33.261Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/8c/ccc1bf2610243bdb3ba39547666be33b66a3959e53022a1209a4c893e4cc/uipath_runtime-0.9.2-py3-none-any.whl", hash = "sha256:6a08e86d68ccbc2cb34dc2d101b9cec54b100d33587d730dfc0e22ae80a7c4c8", size = 41704, upload-time = "2026-02-27T08:31:33.118Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/52/b50ad909e7025f8731422f0cf62c1143d674c445fe128e94d7f652bdfaa3/uipath_runtime-0.10.2-py3-none-any.whl", hash = "sha256:394c78d1666fc049ceab30d65faaf8f9f51c97831ef67468a174bf2ffd7d2217", size = 43058, upload-time = "2026-04-29T08:10:31.315Z" },
 ]
 
 [[package]]

--- a/packages/uipath-pydantic-ai/pyproject.toml
+++ b/packages/uipath-pydantic-ai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-pydantic-ai"
-version = "0.0.3"
+version = "0.0.4"
 description = "Python SDK that enables developers to build and deploy PydanticAI agents to the UiPath Cloud Platform"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -8,7 +8,7 @@ dependencies = [
     "pydantic-ai>=1.63.0, <2.0.0",
     "openinference-instrumentation-pydantic-ai>=0.1.12",
     "uipath>=2.10.2, <2.11.0",
-    "uipath-runtime>=0.9.2, <0.10.0",
+    "uipath-runtime>=0.10.0, <0.11.0",
 ]
 classifiers = [
     "Intended Audience :: Developers",

--- a/packages/uipath-pydantic-ai/uv.lock
+++ b/packages/uipath-pydantic-ai/uv.lock
@@ -311,12 +311,20 @@ sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/90/543f556fcfcfa270713eef906b6352ab048e1e557afec12925c991dc93c2/caio-0.9.25-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d6956d9e4a27021c8bd6c9677f3a59eb1d820cc32d0343cea7961a03b1371965", size = 36839, upload-time = "2025-12-26T15:21:40.267Z" },
     { url = "https://files.pythonhosted.org/packages/51/3b/36f3e8ec38dafe8de4831decd2e44c69303d2a3892d16ceda42afed44e1b/caio-0.9.25-cp311-cp311-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf84bfa039f25ad91f4f52944452a5f6f405e8afab4d445450978cd6241d1478", size = 80255, upload-time = "2025-12-26T15:22:20.271Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ce/65e64867d928e6aff1b4f0e12dba0ef6d5bf412c240dc1df9d421ac10573/caio-0.9.25-cp311-cp311-manylinux_2_34_aarch64.whl", hash = "sha256:ae3d62587332bce600f861a8de6256b1014d6485cfd25d68c15caf1611dd1f7c", size = 80052, upload-time = "2026-03-04T22:08:20.402Z" },
+    { url = "https://files.pythonhosted.org/packages/46/90/e278863c47e14ec58309aa2e38a45882fbe67b4cc29ec9bc8f65852d3e45/caio-0.9.25-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:fc220b8533dcf0f238a6b1a4a937f92024c71e7b10b5a2dfc1c73604a25709bc", size = 78273, upload-time = "2026-03-04T22:08:21.368Z" },
     { url = "https://files.pythonhosted.org/packages/d3/25/79c98ebe12df31548ba4eaf44db11b7cad6b3e7b4203718335620939083c/caio-0.9.25-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb7ff95af4c31ad3f03179149aab61097a71fd85e05f89b4786de0359dffd044", size = 36983, upload-time = "2025-12-26T15:21:36.075Z" },
     { url = "https://files.pythonhosted.org/packages/a3/2b/21288691f16d479945968a0a4f2856818c1c5be56881d51d4dac9b255d26/caio-0.9.25-cp312-cp312-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:97084e4e30dfa598449d874c4d8e0c8d5ea17d2f752ef5e48e150ff9d240cd64", size = 82012, upload-time = "2025-12-26T15:22:20.983Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/8a1b580875303500a9c12b9e0af58cb82e47f5bcf888c2457742a138273c/caio-0.9.25-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:4fa69eba47e0f041b9d4f336e2ad40740681c43e686b18b191b6c5f4c5544bfb", size = 81502, upload-time = "2026-03-04T22:08:22.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/0fe770b8ffc8362c48134d1592d653a81a3d8748d764bec33864db36319d/caio-0.9.25-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:6bebf6f079f1341d19f7386db9b8b1f07e8cc15ae13bfdaff573371ba0575d69", size = 80200, upload-time = "2026-03-04T22:08:23.382Z" },
     { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
     { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
     { url = "https://files.pythonhosted.org/packages/69/ca/a08fdc7efdcc24e6a6131a93c85be1f204d41c58f474c42b0670af8c016b/caio-0.9.25-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fab6078b9348e883c80a5e14b382e6ad6aabbc4429ca034e76e730cf464269db", size = 36978, upload-time = "2025-12-26T15:21:41.055Z" },
     { url = "https://files.pythonhosted.org/packages/5e/6c/d4d24f65e690213c097174d26eda6831f45f4734d9d036d81790a27e7b78/caio-0.9.25-cp314-cp314-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44a6b58e52d488c75cfaa5ecaa404b2b41cc965e6c417e03251e868ecd5b6d77", size = 81832, upload-time = "2025-12-26T15:22:22.757Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a4/e534cf7d2d0e8d880e25dd61e8d921ffcfe15bd696734589826f5a2df727/caio-0.9.25-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:628a630eb7fb22381dd8e3c8ab7f59e854b9c806639811fc3f4310c6bd711d79", size = 81565, upload-time = "2026-03-04T22:08:27.483Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ed/bf81aeac1d290017e5e5ac3e880fd56ee15e50a6d0353986799d1bc5cfd5/caio-0.9.25-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:0ba16aa605ccb174665357fc729cf500679c2d94d5f1458a6f0d5ca48f2060a7", size = 80071, upload-time = "2026-03-04T22:08:28.751Z" },
     { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
 ]
 
@@ -1060,6 +1068,7 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]
@@ -3329,6 +3338,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlparse"
+version = "0.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3596,7 +3614,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.2"
+version = "2.10.58"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "applicationinsights" },
@@ -3619,44 +3637,45 @@ dependencies = [
     { name = "uipath-platform" },
     { name = "uipath-runtime" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/c5/f91d2f867a97083b9bb1eaed3c70c41f041a9e69e0c037f6d6086e776101/uipath-2.10.2.tar.gz", hash = "sha256:4718eddfc9a1693763b1546499c582fad375b300051b56a24d241b5f943541af", size = 2453250, upload-time = "2026-02-27T19:32:39.526Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/49/f8b42feee9b488341510bd7b1ae4341895587ff208455c4e4b3bdff35279/uipath-2.10.58.tar.gz", hash = "sha256:ce7a67cfa2c96a563e6174a77c760803b4ce74966473962beea227d9cf7ab530", size = 2933008, upload-time = "2026-04-28T08:11:32.029Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/6d/8e3eaac5b7983433ef98701b66b3f342842fd92f174cd2660230de84b254/uipath-2.10.2-py3-none-any.whl", hash = "sha256:32d1c4f19a4902870eb663cc32f6383e817464a00de192e5e76f399aabec5807", size = 352847, upload-time = "2026-02-27T19:32:37.618Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/84/313499014a73560d9bf716a46bdcd272126eae48b320789db4a33e04ea13/uipath-2.10.58-py3-none-any.whl", hash = "sha256:30d52cef46962c6fb584a11d375bb108f3d674e1023b0ae48237e0cd2e137108", size = 389192, upload-time = "2026-04-28T08:11:29.854Z" },
 ]
 
 [[package]]
 name = "uipath-core"
-version = "0.5.3"
+version = "0.5.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/76/568bbe81e2c502b0b3d34b35f0f2d7557ceed58fc9161820d186276b47ac/uipath_core-0.5.3.tar.gz", hash = "sha256:5ff386c9bf85006648f111496b74534925fab1de4b35d5d0c2f6dfdf81e6e103", size = 119096, upload-time = "2026-02-25T14:08:47.548Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/32/47220dd78799dc5c862d8bb30ce15d8979d91c066d210643fdbf83f3b203/uipath_core-0.5.14.tar.gz", hash = "sha256:da50f724f969373548cc1acf1cef83b5c79c925cf513d47a2b9c984590908556", size = 117665, upload-time = "2026-04-29T08:03:07.743Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/35/87a346abe7485c0a63802487050e3550723bfd97925f85cc8814d34bb2a3/uipath_core-0.5.3-py3-none-any.whl", hash = "sha256:2ad9670d3d8e62d7e4f5ed090dffeff00281b8d20d159fff67cac941889d6748", size = 42858, upload-time = "2026-02-25T14:08:46.037Z" },
+    { url = "https://files.pythonhosted.org/packages/48/da/29ca8cd4e64c940339649f2eb8ec604911df08fdc41395f6b4473ca5267f/uipath_core-0.5.14-py3-none-any.whl", hash = "sha256:09bab428b50da0f2757291dcbc992e932976578f16f20070e2eadeea13636b6a", size = 44299, upload-time = "2026-04-29T08:03:06.418Z" },
 ]
 
 [[package]]
 name = "uipath-platform"
-version = "0.0.4"
+version = "0.1.39"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic-function-models" },
+    { name = "sqlparse" },
     { name = "tenacity" },
     { name = "truststore" },
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/da/7bfaa11939f098dff16b123232ec33862d92508f8e38bd8243e2cd9cad5e/uipath_platform-0.0.4.tar.gz", hash = "sha256:fa1fddb26ca1f2fe388a876ed5e3bc629b219eb2a1288cde21c72f1c9cd4e9e3", size = 255031, upload-time = "2026-02-26T14:43:04.375Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/ac/0c685182ecbc35f54a00469c4249282008315d1e71f9dbdee02090aba4c9/uipath_platform-0.1.39.tar.gz", hash = "sha256:9b025221dd109bf3613c846fc7c6ce4c076f061908432026b9c6f8700299522b", size = 329711, upload-time = "2026-04-28T10:46:47.246Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/f3/a952b9dffb45b102fbdfed295d89b97de4dacc0eebbf0f6edc78896219af/uipath_platform-0.0.4-py3-none-any.whl", hash = "sha256:36cd07a3fad6db9e6a6e0741e49f42666fb5df4fd74f4defdd2e88c80396f32d", size = 156065, upload-time = "2026-02-26T14:43:02.772Z" },
+    { url = "https://files.pythonhosted.org/packages/04/dd/113ab28e414db7c2f633821427919bfb6395ddbae330d910d1ec1f03f6a6/uipath_platform-0.1.39-py3-none-any.whl", hash = "sha256:faf223d3059cb28e13a83b1aff6cdec50988bbc5c422d76e7bd9b119887ed145", size = 217542, upload-time = "2026-04-28T10:46:45.215Z" },
 ]
 
 [[package]]
 name = "uipath-pydantic-ai"
-version = "0.0.3"
+version = "0.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "openinference-instrumentation-pydantic-ai" },
@@ -3681,7 +3700,7 @@ requires-dist = [
     { name = "openinference-instrumentation-pydantic-ai", specifier = ">=0.1.12" },
     { name = "pydantic-ai", specifier = ">=1.63.0,<2.0.0" },
     { name = "uipath", specifier = ">=2.10.2,<2.11.0" },
-    { name = "uipath-runtime", specifier = ">=0.9.2,<0.10.0" },
+    { name = "uipath-runtime", specifier = ">=0.10.0,<0.11.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -3697,14 +3716,14 @@ dev = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.9.2"
+version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/33/472056853c70fe350446f11a223e5af1b7122c804a05d1589a21ffdec9ee/uipath_runtime-0.9.2.tar.gz", hash = "sha256:db4fc26fe1c4c4d3b3d7d55d4c664c3ca0f111652583640ba745e3840517d5b1", size = 139286, upload-time = "2026-02-27T08:31:34.645Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/a5/3643d567b291a584de3b9ff1b39734db8041e5c09a97256426212bbe1f33/uipath_runtime-0.10.2.tar.gz", hash = "sha256:885183183f658aa0af785d2cc268426a583b1a6f12276f5bbafa797323217167", size = 141197, upload-time = "2026-04-29T08:10:33.261Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/8c/ccc1bf2610243bdb3ba39547666be33b66a3959e53022a1209a4c893e4cc/uipath_runtime-0.9.2-py3-none-any.whl", hash = "sha256:6a08e86d68ccbc2cb34dc2d101b9cec54b100d33587d730dfc0e22ae80a7c4c8", size = 41704, upload-time = "2026-02-27T08:31:33.118Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/52/b50ad909e7025f8731422f0cf62c1143d674c445fe128e94d7f652bdfaa3/uipath_runtime-0.10.2-py3-none-any.whl", hash = "sha256:394c78d1666fc049ceab30d65faaf8f9f51c97831ef67468a174bf2ffd7d2217", size = 43058, upload-time = "2026-04-29T08:10:31.315Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- bump `uipath-runtime` constraint from `>=0.9.x, <0.10.0` to `>=0.10.0, <0.11.0` in `uipath-agent-framework`, `uipath-google-adk`, `uipath-openai-agents`, `uipath-pydantic-ai`
- patch-bump each affected package version

## Why

the new `uipath` SDK (2.10.58) requires `uipath-runtime>=0.10.1`. with the old runtime cap, fresh installs of these integrations can resolve to older `uipath` versions whose CLI chat bridge still imports symbols deleted in `uipath-core` 0.5.13, producing an `ImportError` at startup. moving the runtime floor up keeps the integrations on the same line that langchain and llamaindex already use.