### PR TITLE
fix(llms): use Authorization Bearer header in UiPathOpenAI

### DIFF
--- a/packages/uipath-llamaindex/pyproject.toml
+++ b/packages/uipath-llamaindex/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-llamaindex"
-version = "0.5.12"
+version = "0.5.13"
 description = "Python SDK that enables developers to build and deploy LlamaIndex agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-llamaindex/src/uipath_llamaindex/llms/_openai.py
+++ b/packages/uipath-llamaindex/src/uipath_llamaindex/llms/_openai.py
@@ -50,7 +50,9 @@ class UiPathOpenAI(AzureOpenAI):
         api_version: str = "2024-10-21",
         **kwargs: Any,
     ):
+        token = os.environ.get("UIPATH_ACCESS_TOKEN")
         default_headers_dict = {
+            "Authorization": f"Bearer {token}",
             "X-UiPath-LlmGateway-ApiFlavor": "auto",
             "X-UiPath-LlmGateway-RequestingProduct": "uipath-python-sdk",
             "X-UiPath-LlmGateway-RequestingFeature": "llama-index-agent",
@@ -74,7 +76,7 @@ class UiPathOpenAI(AzureOpenAI):
             "model": model_value,
             "deployment_name": model_value,
             "azure_endpoint": f"{base_url}/{vendor_endpoint}",
-            "api_key": os.environ.get("UIPATH_ACCESS_TOKEN"),
+            "api_key": "uipath-gateway",
             "api_version": api_version,
             "is_chat_model": True,
             "default_headers": default_headers_dict,

--- a/packages/uipath-llamaindex/uv.lock
+++ b/packages/uipath-llamaindex/uv.lock
@@ -3496,7 +3496,7 @@ wheels = [
 
 [[package]]
 name = "uipath-llamaindex"
-version = "0.5.12"
+version = "0.5.13"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- `UiPathOpenAI` was passing `UIPATH_ACCESS_TOKEN` as `api_key=` to `AzureOpenAI`. The OpenAI SDK emits that as the Azure-style `api-key:` header, but AgentHub's LLMProxy `[Authorize]` pipeline (JwtBearer + S2S schemes) only reads `Authorization: Bearer`. The request arrived with no `Authorization` header and was rejected anonymously → 401.
- App Insights (prd-ne, `ahub-prd-global-ne-ais`) confirms every 401 on `POST LLMProxy/RawVendorCompletionsAsync` for the openai path has `Auth.HasAuthorizationHeader: false`, no `JWT.*` claims, no upstream dependency emitted — i.e. rejected at AgentHub auth, never reaching LLM Gateway. Same caller succeeded on `vertexai` 19s before with `HasAuthorizationHeader: true`.
- The fix mirrors what `UiPathChatBedrock`/`UiPathChatBedrockConverse` (`bedrock.py:127-131`) and `UiPathVertex` (`vertex.py:247-256`) already do: attach `Authorization: Bearer <UIPATH_ACCESS_TOKEN>` in `default_headers`. A placeholder `api_key="uipath-gateway"` keeps the `AzureOpenAI` constructor happy.

## Test plan
- [ ] CI `uipath-llamaindex/chat-models / staging` (UiPathOpenAI) — 10 methods flip from 401 to ✓
- [ ] CI `uipath-llamaindex/quickstart-agent / cloud` — passes
- [ ] CI `uipath-llamaindex/simple-hitl-agent / staging` and `/ cloud` — pass
- [ ] App Insights spot-check: a `dependencies` row to LLM Gateway now appears for these `operation_Id`s (proves auth passed)
- [ ] `UiPathChatBedrockConverse`, `UiPathChatBedrock`, `UiPathVertex` keep passing (unaffected)

## Note on out-of-scope CI failures
The `*/alpha` matrix cells (`debug-breakpoints / alpha`, `quickstart-agent / alpha`, `simple-hitl-agent / alpha`) fail before any LLM call with `❌ Failed to get tenants and organizations:` — separate alpha-env credential issue, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)