### PR TITLE
chore: bump uipath-runtime to >=0.11.0 across integrations

### DIFF
--- a/packages/uipath-agent-framework/pyproject.toml
+++ b/packages/uipath-agent-framework/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-agent-framework"
-version = "0.0.12"
+version = "0.0.13"
 description = "Python SDK that enables developers to build and deploy Microsoft Agent Framework agents to the UiPath Cloud Platform"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -10,7 +10,7 @@ dependencies = [
     "aiosqlite>=0.20.0",
     "openinference-instrumentation-agent-framework>=0.1.0",
     "uipath>=2.10.0, <2.11.0",
-    "uipath-runtime>=0.10.0, <0.11.0",
+    "uipath-runtime>=0.11.0, <0.12.0",
 ]
 classifiers = [
     "Intended Audience :: Developers",

--- a/packages/uipath-agent-framework/tests/test_hitl_e2e.py
+++ b/packages/uipath-agent-framework/tests/test_hitl_e2e.py
@@ -71,6 +71,7 @@ class MockChatBridge:
         self.auto_approve = auto_approve
         self.interrupts: list[UiPathResumeTrigger] = []
         self.messages: list[Any] = []
+        self.executing_tool_calls: list[tuple[str, dict[str, Any] | None]] = []
 
     async def connect(self) -> None:
         pass
@@ -83,6 +84,13 @@ class MockChatBridge:
 
     async def emit_interrupt_event(self, resume_trigger: UiPathResumeTrigger) -> None:
         self.interrupts.append(resume_trigger)
+
+    async def emit_executing_tool_call_event(
+        self,
+        tool_call_id: str,
+        tool_input: dict[str, Any] | None = None,
+    ) -> None:
+        self.executing_tool_calls.append((tool_call_id, tool_input))
 
     async def emit_exchange_end_event(self) -> None:
         pass

--- a/packages/uipath-agent-framework/uv.lock
+++ b/packages/uipath-agent-framework/uv.lock
@@ -2448,7 +2448,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.58"
+version = "2.10.78"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "applicationinsights" },
@@ -2471,14 +2471,14 @@ dependencies = [
     { name = "uipath-platform" },
     { name = "uipath-runtime" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/49/f8b42feee9b488341510bd7b1ae4341895587ff208455c4e4b3bdff35279/uipath-2.10.58.tar.gz", hash = "sha256:ce7a67cfa2c96a563e6174a77c760803b4ce74966473962beea227d9cf7ab530", size = 2933008, upload-time = "2026-04-28T08:11:32.029Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/7b/ea510b8a6a29c7b74d0f43c52868db921bba18569545e30a183a9fa1a2ad/uipath-2.10.78.tar.gz", hash = "sha256:8b8ee48e719daa923c048c521ca6e8cd0fd179ba2d96ed92259c5a287783fe7a", size = 4434281, upload-time = "2026-06-05T20:38:56.218Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/84/313499014a73560d9bf716a46bdcd272126eae48b320789db4a33e04ea13/uipath-2.10.58-py3-none-any.whl", hash = "sha256:30d52cef46962c6fb584a11d375bb108f3d674e1023b0ae48237e0cd2e137108", size = 389192, upload-time = "2026-04-28T08:11:29.854Z" },
+    { url = "https://files.pythonhosted.org/packages/59/24/d4c7eb09679f7b362f9d077839fd4d906e2b841121f3a3300f4b2055fab8/uipath-2.10.78-py3-none-any.whl", hash = "sha256:b4098a1b7bc693a7f4e74c7af404cfb634dd8f8ce5e83cf2a4893763b788c396", size = 392954, upload-time = "2026-06-05T20:38:54.086Z" },
 ]
 
 [[package]]
 name = "uipath-agent-framework"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "." }
 dependencies = [
     { name = "agent-framework-core" },
@@ -2515,7 +2515,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.43.0" },
     { name = "openinference-instrumentation-agent-framework", specifier = ">=0.1.0" },
     { name = "uipath", specifier = ">=2.10.0,<2.11.0" },
-    { name = "uipath-runtime", specifier = ">=0.10.0,<0.11.0" },
+    { name = "uipath-runtime", specifier = ">=0.11.0,<0.12.0" },
 ]
 provides-extras = ["anthropic"]
 
@@ -2532,21 +2532,21 @@ dev = [
 
 [[package]]
 name = "uipath-core"
-version = "0.5.14"
+version = "0.5.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/32/47220dd78799dc5c862d8bb30ce15d8979d91c066d210643fdbf83f3b203/uipath_core-0.5.14.tar.gz", hash = "sha256:da50f724f969373548cc1acf1cef83b5c79c925cf513d47a2b9c984590908556", size = 117665, upload-time = "2026-04-29T08:03:07.743Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/b1/d4e555a1a2ccf298195a5f2968e538b0cea8592b3e03f43fc12b178d6c69/uipath_core-0.5.18.tar.gz", hash = "sha256:63ebe8bdb818ca30a4bc9ab0ea8171315680691429931282939359ce039401ab", size = 131988, upload-time = "2026-06-08T14:04:49.688Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/da/29ca8cd4e64c940339649f2eb8ec604911df08fdc41395f6b4473ca5267f/uipath_core-0.5.14-py3-none-any.whl", hash = "sha256:09bab428b50da0f2757291dcbc992e932976578f16f20070e2eadeea13636b6a", size = 44299, upload-time = "2026-04-29T08:03:06.418Z" },
+    { url = "https://files.pythonhosted.org/packages/57/de/1a820b33f7bff4565d7649772bc54c88480ac7e70f707097f7da37d05157/uipath_core-0.5.18-py3-none-any.whl", hash = "sha256:351d6faeecfc6a0acea93182e01526f39c04a77e09fa0444be5f4fb580463f5a", size = 54572, upload-time = "2026-06-08T14:04:48.22Z" },
 ]
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.39"
+version = "0.1.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2556,21 +2556,21 @@ dependencies = [
     { name = "truststore" },
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/ac/0c685182ecbc35f54a00469c4249282008315d1e71f9dbdee02090aba4c9/uipath_platform-0.1.39.tar.gz", hash = "sha256:9b025221dd109bf3613c846fc7c6ce4c076f061908432026b9c6f8700299522b", size = 329711, upload-time = "2026-04-28T10:46:47.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/84/36bd3b31c268d4fcb4e0a42107c87d35415bea6abcfceb6708c894d4c049/uipath_platform-0.1.61.tar.gz", hash = "sha256:96023a121ab6ed343085431f9f5dc00b6a814e373984b57d5c136497dc70a317", size = 372148, upload-time = "2026-06-05T21:48:11.932Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/dd/113ab28e414db7c2f633821427919bfb6395ddbae330d910d1ec1f03f6a6/uipath_platform-0.1.39-py3-none-any.whl", hash = "sha256:faf223d3059cb28e13a83b1aff6cdec50988bbc5c422d76e7bd9b119887ed145", size = 217542, upload-time = "2026-04-28T10:46:45.215Z" },
+    { url = "https://files.pythonhosted.org/packages/41/bc/bb2484d9f7e95d98b0d3b21cfea0de3714c55ad4ab1b85bc2151fa4299bb/uipath_platform-0.1.61-py3-none-any.whl", hash = "sha256:2075481878df4456fbb1058761edecb6d14b3f675d6d916eddf6b4ef96fca6a5", size = 248039, upload-time = "2026-06-05T21:48:10.267Z" },
 ]
 
 [[package]]
 name = "uipath-runtime"
-version = "0.10.2"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/a5/3643d567b291a584de3b9ff1b39734db8041e5c09a97256426212bbe1f33/uipath_runtime-0.10.2.tar.gz", hash = "sha256:885183183f658aa0af785d2cc268426a583b1a6f12276f5bbafa797323217167", size = 141197, upload-time = "2026-04-29T08:10:33.261Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/8d/4d36d6a5dda4ca5f25e52508bc20dd82cb92fcdf2a36cd0adc4f9832d047/uipath_runtime-0.11.0.tar.gz", hash = "sha256:cc94f2fdab43b593ef678eff904fc6cdd4831963cffe39a83909ffcf9082d76f", size = 143685, upload-time = "2026-05-29T15:13:30.562Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/52/b50ad909e7025f8731422f0cf62c1143d674c445fe128e94d7f652bdfaa3/uipath_runtime-0.10.2-py3-none-any.whl", hash = "sha256:394c78d1666fc049ceab30d65faaf8f9f51c97831ef67468a174bf2ffd7d2217", size = 43058, upload-time = "2026-04-29T08:10:31.315Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/08/c7b90851d4544ff5e76ca7c55452597aae1619cf1ebc2c0aa7b098110f14/uipath_runtime-0.11.0-py3-none-any.whl", hash = "sha256:08bf53a0e38bb3d19edc6708d2ecb7d918aa96fdda13e35f3ad0e6f2a6c392b9", size = 43770, upload-time = "2026-05-29T15:13:29.282Z" },
 ]
 
 [[package]]

--- a/packages/uipath-google-adk/pyproject.toml
+++ b/packages/uipath-google-adk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-google-adk"
-version = "0.0.7"
+version = "0.0.8"
 description = "Python SDK that enables developers to build and deploy Google ADK agents to the UiPath Cloud Platform"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -8,7 +8,7 @@ dependencies = [
     "google-adk>=1.25.1",
     "openinference-instrumentation-google-adk>=0.1.9",
     "uipath>=2.10.0, <2.11.0",
-    "uipath-runtime>=0.10.0, <0.11.0",
+    "uipath-runtime>=0.11.0, <0.12.0",
 ]
 classifiers = [
     "Intended Audience :: Developers",

--- a/packages/uipath-google-adk/uv.lock
+++ b/packages/uipath-google-adk/uv.lock
@@ -3561,7 +3561,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.58"
+version = "2.10.78"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "applicationinsights" },
@@ -3584,28 +3584,28 @@ dependencies = [
     { name = "uipath-platform" },
     { name = "uipath-runtime" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/49/f8b42feee9b488341510bd7b1ae4341895587ff208455c4e4b3bdff35279/uipath-2.10.58.tar.gz", hash = "sha256:ce7a67cfa2c96a563e6174a77c760803b4ce74966473962beea227d9cf7ab530", size = 2933008, upload-time = "2026-04-28T08:11:32.029Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/7b/ea510b8a6a29c7b74d0f43c52868db921bba18569545e30a183a9fa1a2ad/uipath-2.10.78.tar.gz", hash = "sha256:8b8ee48e719daa923c048c521ca6e8cd0fd179ba2d96ed92259c5a287783fe7a", size = 4434281, upload-time = "2026-06-05T20:38:56.218Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/84/313499014a73560d9bf716a46bdcd272126eae48b320789db4a33e04ea13/uipath-2.10.58-py3-none-any.whl", hash = "sha256:30d52cef46962c6fb584a11d375bb108f3d674e1023b0ae48237e0cd2e137108", size = 389192, upload-time = "2026-04-28T08:11:29.854Z" },
+    { url = "https://files.pythonhosted.org/packages/59/24/d4c7eb09679f7b362f9d077839fd4d906e2b841121f3a3300f4b2055fab8/uipath-2.10.78-py3-none-any.whl", hash = "sha256:b4098a1b7bc693a7f4e74c7af404cfb634dd8f8ce5e83cf2a4893763b788c396", size = 392954, upload-time = "2026-06-05T20:38:54.086Z" },
 ]
 
 [[package]]
 name = "uipath-core"
-version = "0.5.14"
+version = "0.5.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/32/47220dd78799dc5c862d8bb30ce15d8979d91c066d210643fdbf83f3b203/uipath_core-0.5.14.tar.gz", hash = "sha256:da50f724f969373548cc1acf1cef83b5c79c925cf513d47a2b9c984590908556", size = 117665, upload-time = "2026-04-29T08:03:07.743Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/b1/d4e555a1a2ccf298195a5f2968e538b0cea8592b3e03f43fc12b178d6c69/uipath_core-0.5.18.tar.gz", hash = "sha256:63ebe8bdb818ca30a4bc9ab0ea8171315680691429931282939359ce039401ab", size = 131988, upload-time = "2026-06-08T14:04:49.688Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/da/29ca8cd4e64c940339649f2eb8ec604911df08fdc41395f6b4473ca5267f/uipath_core-0.5.14-py3-none-any.whl", hash = "sha256:09bab428b50da0f2757291dcbc992e932976578f16f20070e2eadeea13636b6a", size = 44299, upload-time = "2026-04-29T08:03:06.418Z" },
+    { url = "https://files.pythonhosted.org/packages/57/de/1a820b33f7bff4565d7649772bc54c88480ac7e70f707097f7da37d05157/uipath_core-0.5.18-py3-none-any.whl", hash = "sha256:351d6faeecfc6a0acea93182e01526f39c04a77e09fa0444be5f4fb580463f5a", size = 54572, upload-time = "2026-06-08T14:04:48.22Z" },
 ]
 
 [[package]]
 name = "uipath-google-adk"
-version = "0.0.7"
+version = "0.0.8"
 source = { editable = "." }
 dependencies = [
     { name = "google-adk" },
@@ -3636,7 +3636,7 @@ requires-dist = [
     { name = "google-adk", specifier = ">=1.25.1" },
     { name = "openinference-instrumentation-google-adk", specifier = ">=0.1.9" },
     { name = "uipath", specifier = ">=2.10.0,<2.11.0" },
-    { name = "uipath-runtime", specifier = ">=0.10.0,<0.11.0" },
+    { name = "uipath-runtime", specifier = ">=0.11.0,<0.12.0" },
 ]
 provides-extras = ["anthropic"]
 
@@ -3653,7 +3653,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.39"
+version = "0.1.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -3663,21 +3663,21 @@ dependencies = [
     { name = "truststore" },
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/ac/0c685182ecbc35f54a00469c4249282008315d1e71f9dbdee02090aba4c9/uipath_platform-0.1.39.tar.gz", hash = "sha256:9b025221dd109bf3613c846fc7c6ce4c076f061908432026b9c6f8700299522b", size = 329711, upload-time = "2026-04-28T10:46:47.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/84/36bd3b31c268d4fcb4e0a42107c87d35415bea6abcfceb6708c894d4c049/uipath_platform-0.1.61.tar.gz", hash = "sha256:96023a121ab6ed343085431f9f5dc00b6a814e373984b57d5c136497dc70a317", size = 372148, upload-time = "2026-06-05T21:48:11.932Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/dd/113ab28e414db7c2f633821427919bfb6395ddbae330d910d1ec1f03f6a6/uipath_platform-0.1.39-py3-none-any.whl", hash = "sha256:faf223d3059cb28e13a83b1aff6cdec50988bbc5c422d76e7bd9b119887ed145", size = 217542, upload-time = "2026-04-28T10:46:45.215Z" },
+    { url = "https://files.pythonhosted.org/packages/41/bc/bb2484d9f7e95d98b0d3b21cfea0de3714c55ad4ab1b85bc2151fa4299bb/uipath_platform-0.1.61-py3-none-any.whl", hash = "sha256:2075481878df4456fbb1058761edecb6d14b3f675d6d916eddf6b4ef96fca6a5", size = 248039, upload-time = "2026-06-05T21:48:10.267Z" },
 ]
 
 [[package]]
 name = "uipath-runtime"
-version = "0.10.2"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/a5/3643d567b291a584de3b9ff1b39734db8041e5c09a97256426212bbe1f33/uipath_runtime-0.10.2.tar.gz", hash = "sha256:885183183f658aa0af785d2cc268426a583b1a6f12276f5bbafa797323217167", size = 141197, upload-time = "2026-04-29T08:10:33.261Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/8d/4d36d6a5dda4ca5f25e52508bc20dd82cb92fcdf2a36cd0adc4f9832d047/uipath_runtime-0.11.0.tar.gz", hash = "sha256:cc94f2fdab43b593ef678eff904fc6cdd4831963cffe39a83909ffcf9082d76f", size = 143685, upload-time = "2026-05-29T15:13:30.562Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/52/b50ad909e7025f8731422f0cf62c1143d674c445fe128e94d7f652bdfaa3/uipath_runtime-0.10.2-py3-none-any.whl", hash = "sha256:394c78d1666fc049ceab30d65faaf8f9f51c97831ef67468a174bf2ffd7d2217", size = 43058, upload-time = "2026-04-29T08:10:31.315Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/08/c7b90851d4544ff5e76ca7c55452597aae1619cf1ebc2c0aa7b098110f14/uipath_runtime-0.11.0-py3-none-any.whl", hash = "sha256:08bf53a0e38bb3d19edc6708d2ecb7d918aa96fdda13e35f3ad0e6f2a6c392b9", size = 43770, upload-time = "2026-05-29T15:13:29.282Z" },
 ]
 
 [[package]]

--- a/packages/uipath-llamaindex/pyproject.toml
+++ b/packages/uipath-llamaindex/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-llamaindex"
-version = "0.5.13"
+version = "0.5.14"
 description = "Python SDK that enables developers to build and deploy LlamaIndex agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -12,7 +12,7 @@ dependencies = [
     "llama-index-llms-azure-openai>=0.4.2",
     "openinference-instrumentation-llama-index>=4.3.9",
     "uipath>=2.10.0, <2.11.0",
-    "uipath-runtime>=0.10.0, <0.11.0",
+    "uipath-runtime>=0.11.0, <0.12.0",
 ]
 classifiers = [
     "Intended Audience :: Developers",

--- a/packages/uipath-llamaindex/uv.lock
+++ b/packages/uipath-llamaindex/uv.lock
@@ -3462,7 +3462,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.32"
+version = "2.10.78"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "applicationinsights" },
@@ -3485,28 +3485,28 @@ dependencies = [
     { name = "uipath-platform" },
     { name = "uipath-runtime" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/3e/57dd2097602a0de1bc11209ebe635b4a1c895eace8f4c388bcdab3220bde/uipath-2.10.32.tar.gz", hash = "sha256:475a194ae441c756ff6100cf2df78f305f85f3a30d247d1e6fc9f980443a6722", size = 2885019, upload-time = "2026-03-26T16:09:56.991Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/7b/ea510b8a6a29c7b74d0f43c52868db921bba18569545e30a183a9fa1a2ad/uipath-2.10.78.tar.gz", hash = "sha256:8b8ee48e719daa923c048c521ca6e8cd0fd179ba2d96ed92259c5a287783fe7a", size = 4434281, upload-time = "2026-06-05T20:38:56.218Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/07/3b6ec65480f8b2fc168d9d00fe7afc63b2a87b7df684790368831e0fda9f/uipath-2.10.32-py3-none-any.whl", hash = "sha256:2aad5c94c5c6d39cde7b32ccadeedd9a5e591169dec89d038ad1b6d6618b1fcb", size = 366322, upload-time = "2026-03-26T16:09:55.004Z" },
+    { url = "https://files.pythonhosted.org/packages/59/24/d4c7eb09679f7b362f9d077839fd4d906e2b841121f3a3300f4b2055fab8/uipath-2.10.78-py3-none-any.whl", hash = "sha256:b4098a1b7bc693a7f4e74c7af404cfb634dd8f8ce5e83cf2a4893763b788c396", size = 392954, upload-time = "2026-06-05T20:38:54.086Z" },
 ]
 
 [[package]]
 name = "uipath-core"
-version = "0.5.8"
+version = "0.5.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/6a/91fe6b46a8c28233868072340d47ca29f4c5feadd40a4b3c501658560dd8/uipath_core-0.5.8.tar.gz", hash = "sha256:8f37ab200a0afe11d56d3dd3b5086b4591185e55c8a0a0b0e66f85ae58580f02", size = 116088, upload-time = "2026-03-26T15:40:50.498Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/b1/d4e555a1a2ccf298195a5f2968e538b0cea8592b3e03f43fc12b178d6c69/uipath_core-0.5.18.tar.gz", hash = "sha256:63ebe8bdb818ca30a4bc9ab0ea8171315680691429931282939359ce039401ab", size = 131988, upload-time = "2026-06-08T14:04:49.688Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/87/fec9cf831ccf9753b9fab09ab759ae9ba8b65eb5a03a9efbf36b654d8d1d/uipath_core-0.5.8-py3-none-any.whl", hash = "sha256:7f3d2ee982fc6c5752a0c702f1c79f6c8160d746e5f50dabc3add16c21732bac", size = 43032, upload-time = "2026-03-26T15:40:48.754Z" },
+    { url = "https://files.pythonhosted.org/packages/57/de/1a820b33f7bff4565d7649772bc54c88480ac7e70f707097f7da37d05157/uipath_core-0.5.18-py3-none-any.whl", hash = "sha256:351d6faeecfc6a0acea93182e01526f39c04a77e09fa0444be5f4fb580463f5a", size = 54572, upload-time = "2026-06-08T14:04:48.22Z" },
 ]
 
 [[package]]
 name = "uipath-llamaindex"
-version = "0.5.13"
+version = "0.5.14"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -3560,7 +3560,7 @@ requires-dist = [
     { name = "llama-index-workflows", specifier = ">=2.18.0,<3.0.0" },
     { name = "openinference-instrumentation-llama-index", specifier = ">=4.3.9" },
     { name = "uipath", specifier = ">=2.10.0,<2.11.0" },
-    { name = "uipath-runtime", specifier = ">=0.10.0,<0.11.0" },
+    { name = "uipath-runtime", specifier = ">=0.11.0,<0.12.0" },
 ]
 provides-extras = ["bedrock", "vertex"]
 
@@ -3580,7 +3580,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.11"
+version = "0.1.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -3590,21 +3590,21 @@ dependencies = [
     { name = "truststore" },
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/14/39/06561ed0c9400beaa4a273b99eb9f62d686aa8f4c404074729a3bb404ca9/uipath_platform-0.1.11.tar.gz", hash = "sha256:3f567a5ce4340c47390fff09f697a15904f225d9600d79373bc49b1660a2ce13", size = 285384, upload-time = "2026-03-26T16:07:54.659Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/84/36bd3b31c268d4fcb4e0a42107c87d35415bea6abcfceb6708c894d4c049/uipath_platform-0.1.61.tar.gz", hash = "sha256:96023a121ab6ed343085431f9f5dc00b6a814e373984b57d5c136497dc70a317", size = 372148, upload-time = "2026-06-05T21:48:11.932Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/55/fecf1552376303c28f45d95fc813cfb6d8722f3a289f98e3a03b6142e566/uipath_platform-0.1.11-py3-none-any.whl", hash = "sha256:3ab0c58500f9e6bb8ae75d62eeb36d91768a776177223e6a836d75705c0c8369", size = 176345, upload-time = "2026-03-26T16:07:53.432Z" },
+    { url = "https://files.pythonhosted.org/packages/41/bc/bb2484d9f7e95d98b0d3b21cfea0de3714c55ad4ab1b85bc2151fa4299bb/uipath_platform-0.1.61-py3-none-any.whl", hash = "sha256:2075481878df4456fbb1058761edecb6d14b3f675d6d916eddf6b4ef96fca6a5", size = 248039, upload-time = "2026-06-05T21:48:10.267Z" },
 ]
 
 [[package]]
 name = "uipath-runtime"
-version = "0.10.0"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/75/64/69462ee01a5607ce36b1fa152c52ac72fb28abe0aa049394406fc0b31525/uipath_runtime-0.10.0.tar.gz", hash = "sha256:d27d58e2252f506c8c0e00f814b37c3863150e8ffcde8e4c6ab14bd98febd3df", size = 139626, upload-time = "2026-03-24T19:42:43.738Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/8d/4d36d6a5dda4ca5f25e52508bc20dd82cb92fcdf2a36cd0adc4f9832d047/uipath_runtime-0.11.0.tar.gz", hash = "sha256:cc94f2fdab43b593ef678eff904fc6cdd4831963cffe39a83909ffcf9082d76f", size = 143685, upload-time = "2026-05-29T15:13:30.562Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/ed/9c0e97a078b96e4d3742ea3515cb30886b08579cd08077cd42a159adf70d/uipath_runtime-0.10.0-py3-none-any.whl", hash = "sha256:4f52df0b56f54e70fcf34fbf74e223d02b97b5a6fd6d8f64bc06782bb5484b07", size = 42097, upload-time = "2026-03-24T19:42:42.359Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/08/c7b90851d4544ff5e76ca7c55452597aae1619cf1ebc2c0aa7b098110f14/uipath_runtime-0.11.0-py3-none-any.whl", hash = "sha256:08bf53a0e38bb3d19edc6708d2ecb7d918aa96fdda13e35f3ad0e6f2a6c392b9", size = 43770, upload-time = "2026-05-29T15:13:29.282Z" },
 ]
 
 [[package]]

--- a/packages/uipath-openai-agents/pyproject.toml
+++ b/packages/uipath-openai-agents/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-openai-agents"
-version = "0.0.10"
+version = "0.0.11"
 description = "Python SDK that enables developers to build and deploy OpenAI agents to the UiPath Cloud Platform"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -10,7 +10,7 @@ dependencies = [
     "openai-agents>=0.6.5",
     "openinference-instrumentation-openai-agents>=1.4.0",
     "uipath>=2.10.0, <2.11.0",
-    "uipath-runtime>=0.10.0, <0.11.0",
+    "uipath-runtime>=0.11.0, <0.12.0",
 ]
 classifiers = [
     "Intended Audience :: Developers",

--- a/packages/uipath-openai-agents/uv.lock
+++ b/packages/uipath-openai-agents/uv.lock
@@ -2304,7 +2304,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.58"
+version = "2.10.78"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "applicationinsights" },
@@ -2327,28 +2327,28 @@ dependencies = [
     { name = "uipath-platform" },
     { name = "uipath-runtime" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/49/f8b42feee9b488341510bd7b1ae4341895587ff208455c4e4b3bdff35279/uipath-2.10.58.tar.gz", hash = "sha256:ce7a67cfa2c96a563e6174a77c760803b4ce74966473962beea227d9cf7ab530", size = 2933008, upload-time = "2026-04-28T08:11:32.029Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/7b/ea510b8a6a29c7b74d0f43c52868db921bba18569545e30a183a9fa1a2ad/uipath-2.10.78.tar.gz", hash = "sha256:8b8ee48e719daa923c048c521ca6e8cd0fd179ba2d96ed92259c5a287783fe7a", size = 4434281, upload-time = "2026-06-05T20:38:56.218Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/84/313499014a73560d9bf716a46bdcd272126eae48b320789db4a33e04ea13/uipath-2.10.58-py3-none-any.whl", hash = "sha256:30d52cef46962c6fb584a11d375bb108f3d674e1023b0ae48237e0cd2e137108", size = 389192, upload-time = "2026-04-28T08:11:29.854Z" },
+    { url = "https://files.pythonhosted.org/packages/59/24/d4c7eb09679f7b362f9d077839fd4d906e2b841121f3a3300f4b2055fab8/uipath-2.10.78-py3-none-any.whl", hash = "sha256:b4098a1b7bc693a7f4e74c7af404cfb634dd8f8ce5e83cf2a4893763b788c396", size = 392954, upload-time = "2026-06-05T20:38:54.086Z" },
 ]
 
 [[package]]
 name = "uipath-core"
-version = "0.5.14"
+version = "0.5.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/32/47220dd78799dc5c862d8bb30ce15d8979d91c066d210643fdbf83f3b203/uipath_core-0.5.14.tar.gz", hash = "sha256:da50f724f969373548cc1acf1cef83b5c79c925cf513d47a2b9c984590908556", size = 117665, upload-time = "2026-04-29T08:03:07.743Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/b1/d4e555a1a2ccf298195a5f2968e538b0cea8592b3e03f43fc12b178d6c69/uipath_core-0.5.18.tar.gz", hash = "sha256:63ebe8bdb818ca30a4bc9ab0ea8171315680691429931282939359ce039401ab", size = 131988, upload-time = "2026-06-08T14:04:49.688Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/da/29ca8cd4e64c940339649f2eb8ec604911df08fdc41395f6b4473ca5267f/uipath_core-0.5.14-py3-none-any.whl", hash = "sha256:09bab428b50da0f2757291dcbc992e932976578f16f20070e2eadeea13636b6a", size = 44299, upload-time = "2026-04-29T08:03:06.418Z" },
+    { url = "https://files.pythonhosted.org/packages/57/de/1a820b33f7bff4565d7649772bc54c88480ac7e70f707097f7da37d05157/uipath_core-0.5.18-py3-none-any.whl", hash = "sha256:351d6faeecfc6a0acea93182e01526f39c04a77e09fa0444be5f4fb580463f5a", size = 54572, upload-time = "2026-06-08T14:04:48.22Z" },
 ]
 
 [[package]]
 name = "uipath-openai-agents"
-version = "0.0.10"
+version = "0.0.11"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -2377,7 +2377,7 @@ requires-dist = [
     { name = "openai-agents", specifier = ">=0.6.5" },
     { name = "openinference-instrumentation-openai-agents", specifier = ">=1.4.0" },
     { name = "uipath", specifier = ">=2.10.0,<2.11.0" },
-    { name = "uipath-runtime", specifier = ">=0.10.0,<0.11.0" },
+    { name = "uipath-runtime", specifier = ">=0.11.0,<0.12.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -2393,7 +2393,7 @@ dev = [
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.39"
+version = "0.1.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2403,21 +2403,21 @@ dependencies = [
     { name = "truststore" },
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/ac/0c685182ecbc35f54a00469c4249282008315d1e71f9dbdee02090aba4c9/uipath_platform-0.1.39.tar.gz", hash = "sha256:9b025221dd109bf3613c846fc7c6ce4c076f061908432026b9c6f8700299522b", size = 329711, upload-time = "2026-04-28T10:46:47.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/84/36bd3b31c268d4fcb4e0a42107c87d35415bea6abcfceb6708c894d4c049/uipath_platform-0.1.61.tar.gz", hash = "sha256:96023a121ab6ed343085431f9f5dc00b6a814e373984b57d5c136497dc70a317", size = 372148, upload-time = "2026-06-05T21:48:11.932Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/dd/113ab28e414db7c2f633821427919bfb6395ddbae330d910d1ec1f03f6a6/uipath_platform-0.1.39-py3-none-any.whl", hash = "sha256:faf223d3059cb28e13a83b1aff6cdec50988bbc5c422d76e7bd9b119887ed145", size = 217542, upload-time = "2026-04-28T10:46:45.215Z" },
+    { url = "https://files.pythonhosted.org/packages/41/bc/bb2484d9f7e95d98b0d3b21cfea0de3714c55ad4ab1b85bc2151fa4299bb/uipath_platform-0.1.61-py3-none-any.whl", hash = "sha256:2075481878df4456fbb1058761edecb6d14b3f675d6d916eddf6b4ef96fca6a5", size = 248039, upload-time = "2026-06-05T21:48:10.267Z" },
 ]
 
 [[package]]
 name = "uipath-runtime"
-version = "0.10.2"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/a5/3643d567b291a584de3b9ff1b39734db8041e5c09a97256426212bbe1f33/uipath_runtime-0.10.2.tar.gz", hash = "sha256:885183183f658aa0af785d2cc268426a583b1a6f12276f5bbafa797323217167", size = 141197, upload-time = "2026-04-29T08:10:33.261Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/8d/4d36d6a5dda4ca5f25e52508bc20dd82cb92fcdf2a36cd0adc4f9832d047/uipath_runtime-0.11.0.tar.gz", hash = "sha256:cc94f2fdab43b593ef678eff904fc6cdd4831963cffe39a83909ffcf9082d76f", size = 143685, upload-time = "2026-05-29T15:13:30.562Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/52/b50ad909e7025f8731422f0cf62c1143d674c445fe128e94d7f652bdfaa3/uipath_runtime-0.10.2-py3-none-any.whl", hash = "sha256:394c78d1666fc049ceab30d65faaf8f9f51c97831ef67468a174bf2ffd7d2217", size = 43058, upload-time = "2026-04-29T08:10:31.315Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/08/c7b90851d4544ff5e76ca7c55452597aae1619cf1ebc2c0aa7b098110f14/uipath_runtime-0.11.0-py3-none-any.whl", hash = "sha256:08bf53a0e38bb3d19edc6708d2ecb7d918aa96fdda13e35f3ad0e6f2a6c392b9", size = 43770, upload-time = "2026-05-29T15:13:29.282Z" },
 ]
 
 [[package]]

--- a/packages/uipath-pydantic-ai/pyproject.toml
+++ b/packages/uipath-pydantic-ai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-pydantic-ai"
-version = "0.0.4"
+version = "0.0.5"
 description = "Python SDK that enables developers to build and deploy PydanticAI agents to the UiPath Cloud Platform"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -8,7 +8,7 @@ dependencies = [
     "pydantic-ai>=1.63.0, <2.0.0",
     "openinference-instrumentation-pydantic-ai>=0.1.12",
     "uipath>=2.10.2, <2.11.0",
-    "uipath-runtime>=0.10.0, <0.11.0",
+    "uipath-runtime>=0.11.0, <0.12.0",
 ]
 classifiers = [
     "Intended Audience :: Developers",

--- a/packages/uipath-pydantic-ai/uv.lock
+++ b/packages/uipath-pydantic-ai/uv.lock
@@ -3624,7 +3624,7 @@ wheels = [
 
 [[package]]
 name = "uipath"
-version = "2.10.58"
+version = "2.10.78"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "applicationinsights" },
@@ -3647,28 +3647,28 @@ dependencies = [
     { name = "uipath-platform" },
     { name = "uipath-runtime" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/49/f8b42feee9b488341510bd7b1ae4341895587ff208455c4e4b3bdff35279/uipath-2.10.58.tar.gz", hash = "sha256:ce7a67cfa2c96a563e6174a77c760803b4ce74966473962beea227d9cf7ab530", size = 2933008, upload-time = "2026-04-28T08:11:32.029Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/7b/ea510b8a6a29c7b74d0f43c52868db921bba18569545e30a183a9fa1a2ad/uipath-2.10.78.tar.gz", hash = "sha256:8b8ee48e719daa923c048c521ca6e8cd0fd179ba2d96ed92259c5a287783fe7a", size = 4434281, upload-time = "2026-06-05T20:38:56.218Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/84/313499014a73560d9bf716a46bdcd272126eae48b320789db4a33e04ea13/uipath-2.10.58-py3-none-any.whl", hash = "sha256:30d52cef46962c6fb584a11d375bb108f3d674e1023b0ae48237e0cd2e137108", size = 389192, upload-time = "2026-04-28T08:11:29.854Z" },
+    { url = "https://files.pythonhosted.org/packages/59/24/d4c7eb09679f7b362f9d077839fd4d906e2b841121f3a3300f4b2055fab8/uipath-2.10.78-py3-none-any.whl", hash = "sha256:b4098a1b7bc693a7f4e74c7af404cfb634dd8f8ce5e83cf2a4893763b788c396", size = 392954, upload-time = "2026-06-05T20:38:54.086Z" },
 ]
 
 [[package]]
 name = "uipath-core"
-version = "0.5.14"
+version = "0.5.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/32/47220dd78799dc5c862d8bb30ce15d8979d91c066d210643fdbf83f3b203/uipath_core-0.5.14.tar.gz", hash = "sha256:da50f724f969373548cc1acf1cef83b5c79c925cf513d47a2b9c984590908556", size = 117665, upload-time = "2026-04-29T08:03:07.743Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/b1/d4e555a1a2ccf298195a5f2968e538b0cea8592b3e03f43fc12b178d6c69/uipath_core-0.5.18.tar.gz", hash = "sha256:63ebe8bdb818ca30a4bc9ab0ea8171315680691429931282939359ce039401ab", size = 131988, upload-time = "2026-06-08T14:04:49.688Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/da/29ca8cd4e64c940339649f2eb8ec604911df08fdc41395f6b4473ca5267f/uipath_core-0.5.14-py3-none-any.whl", hash = "sha256:09bab428b50da0f2757291dcbc992e932976578f16f20070e2eadeea13636b6a", size = 44299, upload-time = "2026-04-29T08:03:06.418Z" },
+    { url = "https://files.pythonhosted.org/packages/57/de/1a820b33f7bff4565d7649772bc54c88480ac7e70f707097f7da37d05157/uipath_core-0.5.18-py3-none-any.whl", hash = "sha256:351d6faeecfc6a0acea93182e01526f39c04a77e09fa0444be5f4fb580463f5a", size = 54572, upload-time = "2026-06-08T14:04:48.22Z" },
 ]
 
 [[package]]
 name = "uipath-platform"
-version = "0.1.39"
+version = "0.1.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -3678,14 +3678,14 @@ dependencies = [
     { name = "truststore" },
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/ac/0c685182ecbc35f54a00469c4249282008315d1e71f9dbdee02090aba4c9/uipath_platform-0.1.39.tar.gz", hash = "sha256:9b025221dd109bf3613c846fc7c6ce4c076f061908432026b9c6f8700299522b", size = 329711, upload-time = "2026-04-28T10:46:47.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/84/36bd3b31c268d4fcb4e0a42107c87d35415bea6abcfceb6708c894d4c049/uipath_platform-0.1.61.tar.gz", hash = "sha256:96023a121ab6ed343085431f9f5dc00b6a814e373984b57d5c136497dc70a317", size = 372148, upload-time = "2026-06-05T21:48:11.932Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/dd/113ab28e414db7c2f633821427919bfb6395ddbae330d910d1ec1f03f6a6/uipath_platform-0.1.39-py3-none-any.whl", hash = "sha256:faf223d3059cb28e13a83b1aff6cdec50988bbc5c422d76e7bd9b119887ed145", size = 217542, upload-time = "2026-04-28T10:46:45.215Z" },
+    { url = "https://files.pythonhosted.org/packages/41/bc/bb2484d9f7e95d98b0d3b21cfea0de3714c55ad4ab1b85bc2151fa4299bb/uipath_platform-0.1.61-py3-none-any.whl", hash = "sha256:2075481878df4456fbb1058761edecb6d14b3f675d6d916eddf6b4ef96fca6a5", size = 248039, upload-time = "2026-06-05T21:48:10.267Z" },
 ]
 
 [[package]]
 name = "uipath-pydantic-ai"
-version = "0.0.4"
+version = "0.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "openinference-instrumentation-pydantic-ai" },
@@ -3710,7 +3710,7 @@ requires-dist = [
     { name = "openinference-instrumentation-pydantic-ai", specifier = ">=0.1.12" },
     { name = "pydantic-ai", specifier = ">=1.63.0,<2.0.0" },
     { name = "uipath", specifier = ">=2.10.2,<2.11.0" },
-    { name = "uipath-runtime", specifier = ">=0.10.0,<0.11.0" },
+    { name = "uipath-runtime", specifier = ">=0.11.0,<0.12.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -3726,14 +3726,14 @@ dev = [
 
 [[package]]
 name = "uipath-runtime"
-version = "0.10.2"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "uipath-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/a5/3643d567b291a584de3b9ff1b39734db8041e5c09a97256426212bbe1f33/uipath_runtime-0.10.2.tar.gz", hash = "sha256:885183183f658aa0af785d2cc268426a583b1a6f12276f5bbafa797323217167", size = 141197, upload-time = "2026-04-29T08:10:33.261Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/8d/4d36d6a5dda4ca5f25e52508bc20dd82cb92fcdf2a36cd0adc4f9832d047/uipath_runtime-0.11.0.tar.gz", hash = "sha256:cc94f2fdab43b593ef678eff904fc6cdd4831963cffe39a83909ffcf9082d76f", size = 143685, upload-time = "2026-05-29T15:13:30.562Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/52/b50ad909e7025f8731422f0cf62c1143d674c445fe128e94d7f652bdfaa3/uipath_runtime-0.10.2-py3-none-any.whl", hash = "sha256:394c78d1666fc049ceab30d65faaf8f9f51c97831ef67468a174bf2ffd7d2217", size = 43058, upload-time = "2026-04-29T08:10:31.315Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/08/c7b90851d4544ff5e76ca7c55452597aae1619cf1ebc2c0aa7b098110f14/uipath_runtime-0.11.0-py3-none-any.whl", hash = "sha256:08bf53a0e38bb3d19edc6708d2ecb7d918aa96fdda13e35f3ad0e6f2a6c392b9", size = 43770, upload-time = "2026-05-29T15:13:29.282Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps the required `uipath-runtime` version to `>=0.11.0, <0.12.0` for all five integration packages, patch-bumps each package's own version, and regenerates the `uv.lock` files.

## Version bumps

| Package | Version | `uipath-runtime` |
|---|---|---|
| uipath-agent-framework | 0.0.12 → 0.0.13 | `>=0.11.0, <0.12.0` |
| uipath-google-adk | 0.0.7 → 0.0.8 | `>=0.11.0, <0.12.0` |
| uipath-llamaindex | 0.5.13 → 0.5.14 | `>=0.11.0, <0.12.0` |
| uipath-openai-agents | 0.0.10 → 0.0.11 | `>=0.11.0, <0.12.0` |
| uipath-pydantic-ai | 0.0.4 → 0.0.5 | `>=0.11.0, <0.12.0` |

## Notes

- Each `uv.lock` was regenerated with `uv lock`; all now resolve `uipath-runtime` to `0.11.0`. Re-resolution also pulled the latest in-range `uipath` / `uipath-core` / `uipath-platform` (consistent with `tool.uv.exclude-newer-package` exempting the uipath packages from the 2-day cutoff).
- Follows the convention of the prior bump (commit `c480c64`, `>=0.10.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)