### PR TITLE
fix: defer llm init in llamaindex scaffold template

### DIFF
--- a/packages/uipath-llamaindex/pyproject.toml
+++ b/packages/uipath-llamaindex/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-llamaindex"
-version = "0.5.14"
+version = "0.5.15"
 description = "Python SDK that enables developers to build and deploy LlamaIndex agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-llamaindex/src/uipath_llamaindex/_cli/_templates/main.py.template
+++ b/packages/uipath-llamaindex/src/uipath_llamaindex/_cli/_templates/main.py.template
@@ -1,3 +1,5 @@
+from functools import cached_property
+
 from llama_index.core.workflow import (
     Event,
     StartEvent,
@@ -5,7 +7,10 @@ from llama_index.core.workflow import (
     Workflow,
     step,
 )
-from llama_index.llms.openai import OpenAI
+
+from uipath_llamaindex.llms import BedrockModel, GeminiModel, OpenAIModel, UiPathOpenAI
+from uipath_llamaindex.llms.bedrock import UiPathChatBedrockConverse
+from uipath_llamaindex.llms.vertex import UiPathVertex
 
 
 class TopicEvent(StartEvent):
@@ -22,7 +27,12 @@ class CritiqueEvent(StopEvent):
 
 
 class JokeFlow(Workflow):
-    llm = OpenAI()
+    @cached_property
+    def llm(self):
+        # Choose your LLM provider by uncommenting one of the following:
+        return UiPathChatBedrockConverse(model=BedrockModel.anthropic_claude_haiku_4_5)
+        # return UiPathOpenAI(model=OpenAIModel.GPT_4_1_MINI_2025_04_14.value)
+        # return UiPathVertex(model=GeminiModel.gemini_2_5_flash)
 
     @step
     async def generate_joke(self, ev: TopicEvent) -> JokeEvent:

--- a/packages/uipath-llamaindex/uv.lock
+++ b/packages/uipath-llamaindex/uv.lock
@@ -3506,7 +3506,7 @@ wheels = [
 
 [[package]]
 name = "uipath-llamaindex"
-version = "0.5.14"
+version = "0.5.15"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- scaffolded llamaindex workflows now build the `OpenAI` llm lazily via a `cached_property` instead of as a class attribute

## Why

`uipath init` imports the entrypoint module to extract the input/output schema. With the llm as a class attribute it was constructed at import time, before `uipath auth` had run. Deferring it to first use lets init succeed without auth.