### PR TITLE
fix: add bedrock,vertex extras to llamaindex scaffold deps

### DIFF
--- a/packages/uipath-llamaindex/docs/quick_start.md
+++ b/packages/uipath-llamaindex/docs/quick_start.md
@@ -104,7 +104,6 @@ Generate your first UiPath LlamaIndex agent:
 ✓  Created 'main.py' file.
 ✓  Created 'llama_index.json' file.
 ✓  Created 'pyproject.toml' file.
-🔧  Please ensure to define OPENAI_API_KEY in your .env file.
 💡  Initialize project: uipath init
 💡  Run agent: uipath run agent '{"topic": "UiPath"}'
 ```
@@ -137,18 +136,6 @@ This command creates the following files:
 | `.env`           | Environment variables and secrets (this file will not be packed & published).                                                     |
 | `uipath.json`    | Input/output JSON schemas and bindings.                                                                                           |
 | `agent.mermaid`  | Graph visual representation.                                                                                                      |
-
-## Set Up Environment Variables
-
-Before running the agent, configure `OPENAI_API_KEY` in the `.env` file:
-
-//// tab | Open AI
-
-```
-OPENAI_API_KEY=sk-proj-......
-```
-
-////
 
 ## Authenticate With UiPath
 

--- a/packages/uipath-llamaindex/pyproject.toml
+++ b/packages/uipath-llamaindex/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-llamaindex"
-version = "0.5.15"
+version = "0.5.16"
 description = "Python SDK that enables developers to build and deploy LlamaIndex agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/packages/uipath-llamaindex/src/uipath_llamaindex/_cli/cli_new.py
+++ b/packages/uipath-llamaindex/src/uipath_llamaindex/_cli/cli_new.py
@@ -31,8 +31,7 @@ version = "0.0.1"
 description = "{project_name}"
 authors = [{{ name = "John Doe", email = "john.doe@myemail.com" }}]
 dependencies = [
-    "uipath-llamaindex>=0.5.0, <0.6.0",
-    "llama-index-llms-openai>=0.6.10"
+    "uipath-llamaindex[bedrock,vertex]>=0.5.0, <0.6.0",
 ]
 requires-python = ">=3.11"
 """
@@ -54,9 +53,6 @@ def llamaindex_new_middleware(name: str) -> MiddlewareResult:
             console.success("Created 'llama_index.json' file.")
             generate_pyproject(directory, name)
             console.success("Created 'pyproject.toml' file.")
-            console.config(
-                f""" Please ensure to define {click.style("OPENAI_API_KEY", fg="bright_yellow")} in your .env file. """
-            )
             init_command = """uipath init"""
             run_command = """uipath run agent '{"topic": "UiPath"}'"""
             console.hint(

--- a/packages/uipath-llamaindex/uv.lock
+++ b/packages/uipath-llamaindex/uv.lock
@@ -3506,7 +3506,7 @@ wheels = [
 
 [[package]]
 name = "uipath-llamaindex"
-version = "0.5.15"
+version = "0.5.16"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- generated llamaindex projects now depend on `uipath-llamaindex[bedrock,vertex]` so the default Bedrock model resolves on `uipath init`
- drop the unused `llama-index-llms-openai` dep (scaffold no longer imports plain `OpenAI`)

## Why

the scaffold template now defaults to a Bedrock model, but the generated `pyproject.toml` didn't pull the provider extra -> `uipath init` failed with "the 'bedrock' extra is required". this follows up #354, which merged before the extras fix landed.