### PR TITLE
chore: replace deprecated gpt-4o-mini model in scaffolds and samples

### DIFF
--- a/packages/uipath-agent-framework/pyproject.toml
+++ b/packages/uipath-agent-framework/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-agent-framework"
-version = "0.0.13"
+version = "0.0.14"
 description = "Python SDK that enables developers to build and deploy Microsoft Agent Framework agents to the UiPath Cloud Platform"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/uipath-agent-framework/src/uipath_agent_framework/_cli/_templates/main.py.template
+++ b/packages/uipath-agent-framework/src/uipath_agent_framework/_cli/_templates/main.py.template
@@ -15,7 +15,7 @@ def get_weather(location: str) -> str:
 
 
 # Create an agent with tools
-agent = OpenAIChatClient(model_id="gpt-4o-mini").as_agent(
+agent = OpenAIChatClient(model_id="gpt-4.1-mini-2025-04-14").as_agent(
     name="weather_agent",
     instructions="You are a helpful weather assistant. Use the get_weather tool to provide weather information.",
     tools=[get_weather],

--- a/packages/uipath-agent-framework/uv.lock
+++ b/packages/uipath-agent-framework/uv.lock
@@ -2478,7 +2478,7 @@ wheels = [
 
 [[package]]
 name = "uipath-agent-framework"
-version = "0.0.13"
+version = "0.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "agent-framework-core" },

--- a/packages/uipath-google-adk/samples/quickstart-agent/main.py
+++ b/packages/uipath-google-adk/samples/quickstart-agent/main.py
@@ -61,7 +61,7 @@ def get_weather(location: str) -> str:
 agent = Agent(
     name="weather_agent",
     model=UiPathGemini(model="gemini-2.5-flash"),
-    # model=UiPathOpenAI(model="gpt-4o-mini-2024-07-18"),
+    # model=UiPathOpenAI(model="gpt-4.1-mini-2025-04-14"),
     # model=UiPathAnthropic(model="anthropic.claude-haiku-4-5-20251001-v1:0"),
     instruction="You are a helpful weather assistant. Use the get_weather tool to provide weather information.",
     tools=[get_weather],

--- a/packages/uipath-llamaindex/samples/chat-agent/main.py
+++ b/packages/uipath-llamaindex/samples/chat-agent/main.py
@@ -4,7 +4,7 @@ from llama_index.core.agent.workflow import AgentWorkflow
 from llama_index.llms.openai import OpenAI
 from llama_index.tools.tavily_research import TavilyToolSpec
 
-llm = OpenAI(model="gpt-4o-mini")
+llm = OpenAI(model="gpt-4.1-mini-2025-04-14")
 tavily_tool = TavilyToolSpec(api_key=os.environ["TAVILY_API_KEY"])
 
 SYSTEM_PROMPT = (

--- a/packages/uipath-openai-agents/samples/company_agent/main.py
+++ b/packages/uipath-openai-agents/samples/company_agent/main.py
@@ -65,7 +65,7 @@ hr_agent = Agent(
 
     Be professional, empathetic, and maintain confidentiality.
     When employees introduce themselves by name, acknowledge them personally.""",
-    model="gpt-4o-mini",
+    model="gpt-4.1-mini-2025-04-14",
     tools=[
         check_pto_balance,
         submit_leave_request,
@@ -101,7 +101,7 @@ procurement_agent = Agent(
 
     Always search for preferred vendors when employees ask about suppliers.
     Be helpful in navigating procurement processes.""",
-    model="gpt-4o-mini",
+    model="gpt-4.1-mini-2025-04-14",
     tools=[
         check_budget_availability,
         get_vendor_information,
@@ -140,7 +140,7 @@ policy_agent = Agent(
 
     Be clear, precise, and cite specific policy sections.
     If employees have complex scenarios, help them submit clarification requests.""",
-    model="gpt-4o-mini",
+    model="gpt-4.1-mini-2025-04-14",
     tools=[
         get_company_policy,
         check_compliance_status,

--- a/packages/uipath-pydantic-ai/samples/graph-flow/main.py
+++ b/packages/uipath-pydantic-ai/samples/graph-flow/main.py
@@ -59,7 +59,7 @@ class BlogState:
 
 # --- Agents ---
 
-MODEL = "gpt-4o-mini-2024-07-18"
+MODEL = "gpt-4.1-mini-2025-04-14"
 uipath_client = UiPathChatOpenAI(model_name=MODEL)
 
 writer_agent = Agent(

--- a/packages/uipath-pydantic-ai/samples/multi-agent/main.py
+++ b/packages/uipath-pydantic-ai/samples/multi-agent/main.py
@@ -38,7 +38,7 @@ class ReportOutput(BaseModel):
     code_snippet: str = Field(description="A relevant Python code example")
 
 
-MODEL = "gpt-4o-mini-2024-07-18"
+MODEL = "gpt-4.1-mini-2025-04-14"
 uipath_client = UiPathChatOpenAI(model_name=MODEL)
 
 

--- a/packages/uipath-pydantic-ai/samples/programmatic-handoff/main.py
+++ b/packages/uipath-pydantic-ai/samples/programmatic-handoff/main.py
@@ -50,7 +50,7 @@ class SupportResponse(BaseModel):
 
 # --- Agents ---
 
-MODEL = "gpt-4o-mini-2024-07-18"
+MODEL = "gpt-4.1-mini-2025-04-14"
 uipath_client = UiPathChatOpenAI(model_name=MODEL)
 
 # Step 1: Classify the request

--- a/packages/uipath-pydantic-ai/samples/quickstart-agent/main.py
+++ b/packages/uipath-pydantic-ai/samples/quickstart-agent/main.py
@@ -56,7 +56,7 @@ def get_weather(ctx: RunContext[None], location: str) -> str:
         return f"Weather fetch failed: {e}"
 
 
-uipath_client = UiPathChatOpenAI(model_name="gpt-4o-mini-2024-07-18")
+uipath_client = UiPathChatOpenAI(model_name="gpt-4.1-mini-2025-04-14")
 
 agent = Agent(
     uipath_client.model,

--- a/packages/uipath-pydantic-ai/samples/structured-io/main.py
+++ b/packages/uipath-pydantic-ai/samples/structured-io/main.py
@@ -36,7 +36,7 @@ class ResearchOutput(BaseModel):
     )
 
 
-uipath_client = UiPathChatOpenAI(model_name="gpt-4o-mini-2024-07-18")
+uipath_client = UiPathChatOpenAI(model_name="gpt-4.1-mini-2025-04-14")
 
 agent = Agent(
     uipath_client.model,


### PR DESCRIPTION
## Summary
- update the `uipath new` agent-framework scaffold template to `gpt-4.1-mini-2025-04-14` (was `gpt-4o-mini`)
- swap deprecated `gpt-4o-mini` / `gpt-4o-mini-2024-07-18` for `gpt-4.1-mini-2025-04-14` in pydantic-ai, google-adk, llamaindex, and openai-agents samples

## Why

the `gpt-4o-mini` family is deprecated, so the scaffold generated by `uipath new` and the samples should default to a current openai model resolved via `uip codedagent list-models`.