### PR TITLE
feat: send codedagentsplayground agenthub-config for coded agents (llamaindex, openai-agents, pydantic ai)

### DIFF
--- a/packages/uipath-llamaindex/pyproject.toml
+++ b/packages/uipath-llamaindex/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-llamaindex"
-version = "0.6.0"
+version = "0.6.1"
 description = "Python SDK that enables developers to build and deploy LlamaIndex agents to the UiPath Cloud Platform"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -12,6 +12,7 @@ dependencies = [
     "llama-index-llms-azure-openai>=0.4.2",
     "openinference-instrumentation-llama-index>=4.3.9",
     "uipath>=2.13.0, <2.14.0",
+    "uipath-platform>=0.2.18, <0.3.0",
     "uipath-runtime>=0.12.1, <0.13.0",
 ]
 classifiers = [

--- a/packages/uipath-llamaindex/pyproject.toml
+++ b/packages/uipath-llamaindex/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "llama-index-llms-azure-openai>=0.4.2",
     "openinference-instrumentation-llama-index>=4.3.9",
     "uipath>=2.13.0, <2.14.0",
-    "uipath-platform>=0.2.18, <0.3.0",
+    "uipath-platform>=0.2.19, <0.3.0",
     "uipath-runtime>=0.12.1, <0.13.0",
 ]
 classifiers = [

--- a/packages/uipath-llamaindex/src/uipath_llamaindex/llms/_openai.py
+++ b/packages/uipath-llamaindex/src/uipath_llamaindex/llms/_openai.py
@@ -6,6 +6,8 @@ from llama_index.core.base.llms.types import ChatResponse
 from llama_index.core.tools import ToolSelection
 from llama_index.llms.azure_openai import AzureOpenAI  # type: ignore
 from uipath._utils._ssl_context import get_httpx_client_kwargs
+from uipath.platform.common import resolve_coded_agenthub_config
+from uipath.platform.constants import HEADER_AGENTHUB_CONFIG
 from uipath.utils import EndpointManager
 
 from .supported_models import OpenAIModel
@@ -57,6 +59,10 @@ class UiPathOpenAI(AzureOpenAI):
             "X-UiPath-LlmGateway-RequestingProduct": "uipath-python-sdk",
             "X-UiPath-LlmGateway-RequestingFeature": "llama-index-agent",
         }
+        # Design-time runs (local / Studio Web / debug) meter as CodedAgents.Playground;
+        # deployed runs send no header (-> AgentHub.LLM).
+        if agenthub_config := resolve_coded_agenthub_config():
+            default_headers_dict[HEADER_AGENTHUB_CONFIG] = agenthub_config
         model_value = model.value if isinstance(model, OpenAIModel) else model
 
         base_url = os.environ.get("UIPATH_URL", "EMPTY").rstrip("/")

--- a/packages/uipath-llamaindex/src/uipath_llamaindex/llms/bedrock.py
+++ b/packages/uipath-llamaindex/src/uipath_llamaindex/llms/bedrock.py
@@ -2,6 +2,8 @@ import logging
 import os
 from typing import Any, Optional, Sequence
 
+from uipath.platform.common import resolve_coded_agenthub_config
+from uipath.platform.constants import HEADER_AGENTHUB_CONFIG
 from uipath.utils import EndpointManager
 
 from .supported_models import BedrockModel
@@ -129,6 +131,10 @@ class AwsBedrockCompletionsPassthroughClient:
             "X-UiPath-LlmGateway-ApiFlavor": self.api_flavor,
             "X-UiPath-Streaming-Enabled": streaming,
         }
+
+        # Design-time runs meter as CodedAgents.Playground; deployed -> AgentHub.LLM.
+        if agenthub_config := resolve_coded_agenthub_config():
+            headers[HEADER_AGENTHUB_CONFIG] = agenthub_config
 
         job_key = os.getenv("UIPATH_JOB_KEY")
         process_key = os.getenv("UIPATH_PROCESS_KEY")

--- a/packages/uipath-llamaindex/src/uipath_llamaindex/llms/vertex.py
+++ b/packages/uipath-llamaindex/src/uipath_llamaindex/llms/vertex.py
@@ -6,6 +6,8 @@ import httpx
 from llama_index.core.callbacks import CallbackManager
 from llama_index.core.constants import DEFAULT_NUM_OUTPUTS, DEFAULT_TEMPERATURE
 from uipath._utils._ssl_context import get_httpx_client_kwargs
+from uipath.platform.common import resolve_coded_agenthub_config
+from uipath.platform.constants import HEADER_AGENTHUB_CONFIG
 from uipath.utils import EndpointManager
 
 from .supported_models import GeminiModel
@@ -67,6 +69,9 @@ def _rewrite_request_for_gateway(
         headers = dict(request.headers)
         if is_streaming:
             headers["X-UiPath-Streaming-Enabled"] = "true"
+        # Design-time runs meter as CodedAgents.Playground; deployed -> AgentHub.LLM.
+        if agenthub_config := resolve_coded_agenthub_config():
+            headers[HEADER_AGENTHUB_CONFIG] = agenthub_config
         # Update host header to match the gateway URL
         gateway_url_parsed = httpx.URL(gateway_url)
         headers["host"] = gateway_url_parsed.host

--- a/packages/uipath-llamaindex/tests/llms/test_openai.py
+++ b/packages/uipath-llamaindex/tests/llms/test_openai.py
@@ -69,3 +69,35 @@ def test_init_builds_gateway_endpoint_from_enum_model(monkeypatch):
     assert llm.azure_endpoint.startswith("https://cloud.uipath.com/org/tenant/")
     assert "openai" in llm.azure_endpoint
     assert not llm.azure_endpoint.endswith("/completions")
+
+
+def test_default_headers_include_agenthub_config_at_design_time(monkeypatch, tmp_path):
+    from uipath.platform.common import UiPathConfig
+
+    monkeypatch.setenv("UIPATH_URL", "https://cloud.uipath.com/org/tenant/")
+    monkeypatch.setenv("UIPATH_ACCESS_TOKEN", "token")
+    monkeypatch.delenv("UIPATH_JOB_KEY", raising=False)
+    monkeypatch.delenv("UIPATH_PROJECT_ID", raising=False)
+    monkeypatch.chdir(tmp_path)
+    UiPathConfig.reset()
+
+    llm = UiPathOpenAI(model=OpenAIModel.GPT_4O_2024_08_06)
+    assert (
+        llm.default_headers.get("x-uipath-agenthub-config") == "codedagentsplayground"
+    )
+    UiPathConfig.reset()
+
+
+def test_default_headers_omit_agenthub_config_when_deployed(monkeypatch, tmp_path):
+    from uipath.platform.common import UiPathConfig
+
+    monkeypatch.setenv("UIPATH_URL", "https://cloud.uipath.com/org/tenant/")
+    monkeypatch.setenv("UIPATH_ACCESS_TOKEN", "token")
+    monkeypatch.setenv("UIPATH_JOB_KEY", "deployed-job")
+    monkeypatch.delenv("UIPATH_PROJECT_ID", raising=False)
+    monkeypatch.chdir(tmp_path)
+    UiPathConfig.reset()
+
+    llm = UiPathOpenAI(model=OpenAIModel.GPT_4O_2024_08_06)
+    assert "x-uipath-agenthub-config" not in (llm.default_headers or {})
+    UiPathConfig.reset()

--- a/packages/uipath-openai-agents/pyproject.toml
+++ b/packages/uipath-openai-agents/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-openai-agents"
-version = "0.1.0"
+version = "0.1.1"
 description = "Python SDK that enables developers to build and deploy OpenAI agents to the UiPath Cloud Platform"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -10,6 +10,7 @@ dependencies = [
     "openai-agents>=0.6.5",
     "openinference-instrumentation-openai-agents>=1.4.0",
     "uipath>=2.13.0, <2.14.0",
+    "uipath-platform>=0.2.18, <0.3.0",
     "uipath-runtime>=0.12.1, <0.13.0",
 ]
 classifiers = [

--- a/packages/uipath-openai-agents/pyproject.toml
+++ b/packages/uipath-openai-agents/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "openai-agents>=0.6.5",
     "openinference-instrumentation-openai-agents>=1.4.0",
     "uipath>=2.13.0, <2.14.0",
-    "uipath-platform>=0.2.18, <0.3.0",
+    "uipath-platform>=0.2.19, <0.3.0",
     "uipath-runtime>=0.12.1, <0.13.0",
 ]
 classifiers = [

--- a/packages/uipath-openai-agents/src/uipath_openai_agents/chat/openai.py
+++ b/packages/uipath-openai-agents/src/uipath_openai_agents/chat/openai.py
@@ -6,6 +6,7 @@ from typing import Optional
 import httpx
 from openai import AsyncOpenAI, OpenAI
 from uipath._utils._ssl_context import get_httpx_client_kwargs
+from uipath.platform.common import resolve_coded_agenthub_config
 from uipath.utils import EndpointManager
 
 from .supported_models import OpenAIModels
@@ -145,7 +146,14 @@ class UiPathChatOpenAI:
         self._model_name = model_name
         self._api_version = api_version
         self._vendor = "openai"
-        self._agenthub_config = agenthub_config
+        # Default to the coded-agent design-time/deployed marker when the caller
+        # did not set one, so design-time runs meter as CodedAgents.Playground and
+        # deployed runs fall back to AgentHub.LLM.
+        self._agenthub_config = (
+            agenthub_config
+            if agenthub_config is not None
+            else resolve_coded_agenthub_config()
+        )
         self._byo_connection_id = byo_connection_id
         self._api_flavor = api_flavor
         self._extra_headers = extra_headers or {}

--- a/packages/uipath-openai-agents/src/uipath_openai_agents/chat/openai.py
+++ b/packages/uipath-openai-agents/src/uipath_openai_agents/chat/openai.py
@@ -146,14 +146,8 @@ class UiPathChatOpenAI:
         self._model_name = model_name
         self._api_version = api_version
         self._vendor = "openai"
-        # Default to the coded-agent design-time/deployed marker when the caller
-        # did not set one, so design-time runs meter as CodedAgents.Playground and
-        # deployed runs fall back to AgentHub.LLM.
-        self._agenthub_config = (
-            agenthub_config
-            if agenthub_config is not None
-            else resolve_coded_agenthub_config()
-        )
+        # Design-time runs default to the coded-agent marker (deployed -> AgentHub.LLM).
+        self._agenthub_config = agenthub_config or resolve_coded_agenthub_config()
         self._byo_connection_id = byo_connection_id
         self._api_flavor = api_flavor
         self._extra_headers = extra_headers or {}

--- a/packages/uipath-openai-agents/tests/test_chat_openai.py
+++ b/packages/uipath-openai-agents/tests/test_chat_openai.py
@@ -64,6 +64,38 @@ def test_build_headers_includes_optional_and_respects_overrides(
     assert headers["X-UiPath-LlmGateway-ApiFlavor"] == "chat-completions"
 
 
+def test_agenthub_config_defaults_to_coded_playground_at_design_time(
+    chat_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """No explicit agenthub_config + no job key (design-time) -> coded playground marker."""
+    from uipath.platform.common import UiPathConfig
+
+    monkeypatch.delenv("UIPATH_JOB_KEY", raising=False)
+    monkeypatch.chdir(tmp_path)
+    UiPathConfig.reset()
+
+    client = UiPathChatOpenAI(token="t", org_id="org", tenant_id="tn")
+    assert (
+        client._build_headers()["X-UiPath-AgentHub-Config"] == "codedagentsplayground"
+    )
+    UiPathConfig.reset()
+
+
+def test_agenthub_config_omitted_when_deployed(
+    chat_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Deployed run (job key, not a studio project, not a debug session) -> no config header."""
+    from uipath.platform.common import UiPathConfig
+
+    monkeypatch.setenv("UIPATH_JOB_KEY", "deployed-job")
+    monkeypatch.chdir(tmp_path)
+    UiPathConfig.reset()
+
+    client = UiPathChatOpenAI(token="t", org_id="org", tenant_id="tn")
+    assert "X-UiPath-AgentHub-Config" not in client._build_headers()
+    UiPathConfig.reset()
+
+
 def test_missing_uipath_url_raises_value_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/packages/uipath-pydantic-ai/pyproject.toml
+++ b/packages/uipath-pydantic-ai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uipath-pydantic-ai"
-version = "0.1.0"
+version = "0.1.1"
 description = "Python SDK that enables developers to build and deploy PydanticAI agents to the UiPath Cloud Platform"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -8,6 +8,7 @@ dependencies = [
     "pydantic-ai>=1.63.0, <2.0.0",
     "openinference-instrumentation-pydantic-ai>=0.1.12",
     "uipath>=2.13.0, <2.14.0",
+    "uipath-platform>=0.2.19, <0.3.0",
     "uipath-runtime>=0.12.1, <0.13.0",
 ]
 classifiers = [

--- a/packages/uipath-pydantic-ai/src/uipath_pydantic_ai/chat/openai.py
+++ b/packages/uipath-pydantic-ai/src/uipath_pydantic_ai/chat/openai.py
@@ -138,14 +138,9 @@ class UiPathChatOpenAI:
         self._model_name = model_name
         self._api_version = api_version
         self._vendor = "openai"
-        # Default to the coded-agent design-time/deployed marker when the caller
-        # did not set one, so design-time runs meter as CodedAgents.Playground and
-        # deployed runs fall back to AgentHub.LLM.
-        self._agenthub_config = (
-            agenthub_config
-            if agenthub_config is not None
-            else resolve_coded_agenthub_config()
-        )
+        # Absent an explicit config, default to the coded-agent playground marker.
+        coded_default = resolve_coded_agenthub_config()
+        self._agenthub_config = agenthub_config or coded_default
         self._byo_connection_id = byo_connection_id
         self._api_flavor = api_flavor
         self._extra_headers = extra_headers or {}

--- a/packages/uipath-pydantic-ai/src/uipath_pydantic_ai/chat/openai.py
+++ b/packages/uipath-pydantic-ai/src/uipath_pydantic_ai/chat/openai.py
@@ -8,6 +8,7 @@ from openai import AsyncOpenAI, OpenAI
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
 from uipath._utils._ssl_context import get_httpx_client_kwargs
+from uipath.platform.common import resolve_coded_agenthub_config
 from uipath.utils import EndpointManager
 
 from .supported_models import OpenAIModels
@@ -137,7 +138,14 @@ class UiPathChatOpenAI:
         self._model_name = model_name
         self._api_version = api_version
         self._vendor = "openai"
-        self._agenthub_config = agenthub_config
+        # Default to the coded-agent design-time/deployed marker when the caller
+        # did not set one, so design-time runs meter as CodedAgents.Playground and
+        # deployed runs fall back to AgentHub.LLM.
+        self._agenthub_config = (
+            agenthub_config
+            if agenthub_config is not None
+            else resolve_coded_agenthub_config()
+        )
         self._byo_connection_id = byo_connection_id
         self._api_flavor = api_flavor
         self._extra_headers = extra_headers or {}

--- a/packages/uipath-pydantic-ai/tests/test_chat.py
+++ b/packages/uipath-pydantic-ai/tests/test_chat.py
@@ -125,6 +125,44 @@ def test_client_build_headers_and_base_url(monkeypatch):
     assert client.model_name == client._model_name
 
 
+def test_agenthub_config_defaults_to_coded_playground_at_design_time(
+    monkeypatch, tmp_path
+):
+    """No explicit agenthub_config + no job key (design-time) -> coded playground marker."""
+    from uipath.platform.common import UiPathConfig
+
+    from uipath_pydantic_ai.chat.openai import UiPathChatOpenAI
+
+    monkeypatch.setenv("UIPATH_URL", "https://cloud.uipath.com/org/tenant/")
+    monkeypatch.delenv("UIPATH_JOB_KEY", raising=False)
+    monkeypatch.delenv("UIPATH_PROJECT_ID", raising=False)
+    monkeypatch.chdir(tmp_path)
+    UiPathConfig.reset()
+
+    client = UiPathChatOpenAI(token="t", org_id="org", tenant_id="tn")
+    assert (
+        client._build_headers()["X-UiPath-AgentHub-Config"] == "codedagentsplayground"
+    )
+    UiPathConfig.reset()
+
+
+def test_agenthub_config_omitted_when_deployed(monkeypatch, tmp_path):
+    """Deployed run (job key, not a studio project, not a debug session) -> no config header."""
+    from uipath.platform.common import UiPathConfig
+
+    from uipath_pydantic_ai.chat.openai import UiPathChatOpenAI
+
+    monkeypatch.setenv("UIPATH_URL", "https://cloud.uipath.com/org/tenant/")
+    monkeypatch.setenv("UIPATH_JOB_KEY", "deployed-job")
+    monkeypatch.delenv("UIPATH_PROJECT_ID", raising=False)
+    monkeypatch.chdir(tmp_path)
+    UiPathConfig.reset()
+
+    client = UiPathChatOpenAI(token="t", org_id="org", tenant_id="tn")
+    assert "X-UiPath-AgentHub-Config" not in client._build_headers()
+    UiPathConfig.reset()
+
+
 def test_client_requires_uipath_url(monkeypatch):
     """Building the base URL without UIPATH_URL set raises ValueError."""
     from uipath_pydantic_ai.chat.openai import UiPathChatOpenAI


### PR DESCRIPTION
## What

Makes **LlamaIndex**, **Pydantic AI** and **OpenAI-Agents** coded agents meter their **design-time** LLM calls as **`CodedAgents.Playground`** (drawing that pool) and deployed runs as **`AgentHub.LLM`** — matching what the LangGraph path already does. Both send `x-uipath-agenthub-config` via the shared **`resolve_coded_agenthub_config()`** helper from `uipath.platform` (design-time → `"codedagentsplayground"`, deployed → `None`).

Neither package depends on `uipath-llm-client`, so they don't inherit the LangGraph change — each builds its own gateway headers. This wires the shared helper into those header paths.

## Changes

**`uipath-openai-agents`** (`chat/openai.py`)
- `UiPathChatOpenAI` defaults `agenthub_config` via the helper when the caller doesn't pass one; the existing `_build_headers()` already emits the header. Explicit `agenthub_config` still wins.

**`uipath-llamaindex`** (all three LLM providers)
- `llms/_openai.py`, `llms/bedrock.py`, `llms/vertex.py`: inject `x-uipath-agenthub-config` into the request headers.

**Both**
- Add `uipath-platform>=0.2.18` (the release adding the helper).
- Tests (openai-agents `_build_headers`; llamaindex `_openai` default headers) covering design-time → marker present, deployed → omitted.
- Version bumps: `uipath-openai-agents 0.1.0→0.1.1`, `uipath-llamaindex 0.6.0→0.6.1`.

## ⚠️ Stacked on an unpublished dependency

Requires **`uipath-platform 0.2.18`**, introduced by **uipath-python [#1860](https://github.com/UiPath/uipath-python/pull/1860)**. Until that publishes, `uv sync` can't resolve the pin, so CI is red and I couldn't run the suites locally — validate early via the repo's `test-core-dev-version` label against a dev build. Merge **#1860 first**.

## Notes
- `ruff check` + `ruff format` clean on all changed files.
- Bedrock/Vertex inject through their request transports (same helper); the shared helper itself is unit-tested in #1860.
- The now-archived standalone `uipath-openai-agents` repo is not touched — this targets the active monorepo home.

Related: AgentHubService #1618 · gitops #551167 · uipath-llm-client #125 · langchain #1035

🤖 Generated with [Claude Code](https://claude.com/claude-code)